### PR TITLE
Touch Display: Update to meet requirements of plugin submission checklist

### DIFF
--- a/touch_display/README.md
+++ b/touch_display/README.md
@@ -1,0 +1,33 @@
+# Touch Display plugin
+
+The plugin enables the display of Volumio's UI on locally connected screens. If the screen offers touch control, apart from keyboard input the UI can be operated from the screen. The plugin focuses on the original Raspberry Pi Foundation 7" display (and compatible DSI displays), but can in principle also be used with displays connected via HDMI or GPIO. However, HDMI and GPIO displays usually require additional action by the user, depending on the type of display and any touch controller present, and **requiring advanced knowledge**.
+
+The following features are available on the plugin’s configuration page (other screens than the the original Raspberry Pi Foundation display may not have all of them available):
+
+## Screen saver
+The options allow setting the timeout in seconds until the screen saver (DPMS state “off”) gets invoked. A value of 0 disables the screen saver.
+Furthermore it is possible to block the screen saver as long as Volumio is in playing state.
+
+## Screen brightness
+For the Raspberry Foundation 7" display the screen brightness can be set. If the current screen brightness should be above 14 and then set to a value below 15 a modal shows up to warn for a very dark screen. The modal offers to test the new (low) value by applying it for 5 seconds before the previous brightness gets restored. After that the user can decide if the new or the previous setting should be kept.
+
+It is possible to define two different brightness values ("brightness 1" and "brightness 2") and to specify the time of day at which each brightness value should be set (e.g. a higher brightness value in the daytime starting at 6:00 and a lower brightness at the night-time starting at 21:00). The time of day values need to follow the 24-hour clock system and the time format hh:mm. If both time of day settings should be identical, the screen brightness will not be changed but only brightness 1 will be applied. Regarding the time values be aware that the plugin uses the system time. The system time might deviate from the local time and can only be changed from the command line currently.
+
+The plugin is also prepared for automatic brightness regulation. The option to use automatic brightness regulation will only show up on the plugin’s configuration page if a file named "/etc/als" exists.
+
+Obviously automatic brightness requires additional hardware in the shape of an ambient light sensor. This is typically an LDR with a voltage divider connected to an ADC like the TI ADS1115. For example if the LDR would be connected to input AIN0 of an ADS1115 measuring single-ended signals in continuous conversion mode the current converted LDR value would appear in "/sys/devices/platform/soc/fe804000.i2c/i2c-1/1-0048/iio:device0/in_voltage0_raw". This file would need to be symlinked to "/etc/als" as the plugin awaits the current value of an ambient light sensor in "/etc/als".
+
+When automatic brightness gets enabled for the first time the light sensor obligatorily has to be “calibrated” according to minimum and maximum screen brightness. The calibration process consists of measuring the ambient light in a first setting (e.g. darkness or twilight) where the lowest screen brightness should be reached and a second setting (e.g. “normal” daylight or bright sunshine) where the highest screen brightness should be reached. Through a dedicated button the calibration process can be repeated anytime if needed. The range of possible screen brightness values can be adjusted through the minimum and maximum screen brightness settings.
+
+Furthermore when using automatic brightness it is possible to define a third “reference” point to form a brightness curve between minimum and maximum screen brightness reaching a “reference” screen brightness at a certain ambient brightness. This can be useful if the progression of screen brightness in accordance to ambient brightness needs to be slowed down or accelerated.
+
+## Display orientation
+The display can be rotated in 90° steps. For the Raspberry Foundation 7" screen the touch direction is rotated accordingly to the display. In principle this works for other screens, too. Depending on the screen additional action might be necessary if ex-factory the X- and/or Y-axis should be inverted and/or the touch function should not be aligned to the display. As there are a lot of different screens in the market with a lot of different ex-factory settings, the plugin does not take care for these partially weird deviations from a screen with display and touch equally rotated and aligned.
+
+When the display orientation setting is changed a modal shows up to inform about a reboot is required. The user has the option to initiate the reboot or proceed (and reboot later).
+
+## GPU memory
+The plugin can control the amount of memory used by the GPU. This setting had to be introduced, because rotating the display by 90° or 270° on a screen with higher resolution requires more GPU memory than 32MB which is the default setting of Volumio. E.g. for a screen with a resolution of 1980x1080 pixels a GPU memory of 34MB has to be set or the screen will stay black.
+
+## Show/hide mouse pointer
+Self explanatory. By default the mouse pointer is hidden.

--- a/touch_display/UIConfig.json
+++ b/touch_display/UIConfig.json
@@ -10,7 +10,7 @@
                 "description": "TRANSLATE.TOUCH_DISPLAY.SCREENSAVER_DESC",
                 "icon": "fa-clock-o",
                 "hidden": "false",
-                "onSave": {"type":"controller", "endpoint":"system_hardware/touch_display", "method":"saveScreensaverConf"},
+                "onSave": {"type":"controller", "endpoint":"user_interface/touch_display", "method":"saveScreensaverConf"},
                 "saveButton": {
                               "label": "TRANSLATE.TOUCH_DISPLAY.APPLY",
                               "data": [
@@ -49,7 +49,7 @@
                 "description": "TRANSLATE.TOUCH_DISPLAY.BRIGHTNESS_DESC",
                 "icon": "fa-sun-o",
                 "hidden": "false",
-                "onSave": {"type":"controller", "endpoint":"system_hardware/touch_display", "method":"saveBrightnessConf"},
+                "onSave": {"type":"controller", "endpoint":"user_interface/touch_display", "method":"saveBrightnessConf"},
                 "saveButton": {
                               "label": "TRANSLATE.TOUCH_DISPLAY.APPLY",
                               "data": [
@@ -108,7 +108,7 @@
                              "element": "button",
                              "doc": "TRANSLATE.TOUCH_DISPLAY.CALIBRATION_DOC",
                              "label": "TRANSLATE.TOUCH_DISPLAY.CALIBRATION",
-                             "onClick": {"type":"controller", "endpoint":"system_hardware/touch_display", "method":"getAlsValue", "data":{"confData": "", "action": "minmax"}},
+                             "onClick": {"type":"controller", "endpoint":"user_interface/touch_display", "method":"getAlsValue", "data":{"confData": "", "action": "minmax"}},
                              "visibleIf": {"field": "autoMode", "value": true}
                              },
                              {
@@ -139,7 +139,7 @@
                              "element": "button",
                              "doc": "TRANSLATE.TOUCH_DISPLAY.GET_MID_ALS_DOC",
                              "label": "TRANSLATE.TOUCH_DISPLAY.GET_MID_ALS",
-                             "onClick": {"type":"controller", "endpoint":"system_hardware/touch_display", "method":"getAlsValue", "data":{"confData": "", "action": "mid"}},
+                             "onClick": {"type":"controller", "endpoint":"user_interface/touch_display", "method":"getAlsValue", "data":{"confData": "", "action": "mid"}},
                              "visibleIf": {"field": "autoMode", "value": true}
                              },
                              {
@@ -211,7 +211,7 @@
                 "description": "TRANSLATE.TOUCH_DISPLAY.ORIENTATION_DESC",
                 "icon": "fa-compass",
                 "hidden": "false",
-                "onSave": {"type":"controller", "endpoint":"system_hardware/touch_display", "method":"saveOrientationConf"},
+                "onSave": {"type":"controller", "endpoint":"user_interface/touch_display", "method":"saveOrientationConf"},
                 "saveButton": {
                               "label": "TRANSLATE.TOUCH_DISPLAY.APPLY",
                               "data": [
@@ -253,7 +253,7 @@
                 "description": "TRANSLATE.TOUCH_DISPLAY.GPUMEM_DESC",
                 "icon": "fa-microchip",
                 "hidden": "false",
-                "onSave": {"type":"controller", "endpoint":"system_hardware/touch_display", "method":"saveGpuMemConf"},
+                "onSave": {"type":"controller", "endpoint":"user_interface/touch_display", "method":"saveGpuMemConf"},
                 "saveButton": {
                               "label": "TRANSLATE.TOUCH_DISPLAY.APPLY",
                               "data": [
@@ -293,7 +293,7 @@
                 "description": "TRANSLATE.TOUCH_DISPLAY.POINTER_DESC",
                 "icon": "fa-mouse-pointer",
                 "hidden": "false",
-                "onSave": {"type":"controller", "endpoint":"system_hardware/touch_display", "method":"savePointerConf"},
+                "onSave": {"type":"controller", "endpoint":"user_interface/touch_display", "method":"savePointerConf"},
                 "saveButton": {
                               "label": "TRANSLATE.TOUCH_DISPLAY.APPLY",
                               "data": [
@@ -317,7 +317,7 @@
                 "description": "TRANSLATE.TOUCH_DISPLAY.SCALE_DESC",
                 "icon": "fa-expand",
                 "hidden": "false",
-                "onSave": {"type":"controller", "endpoint":"system_hardware/touch_display", "method":"saveScaleConf"},
+                "onSave": {"type":"controller", "endpoint":"user_interface/touch_display", "method":"saveScaleConf"},
                 "saveButton": {
                               "label": "TRANSLATE.TOUCH_DISPLAY.APPLY",
                               "data": [

--- a/touch_display/index.js
+++ b/touch_display/index.js
@@ -355,7 +355,7 @@ TouchDisplay.prototype.getUIConfig = function () {
 TouchDisplay.prototype.updateUIConfig = function () {
   const self = this;
 
-  self.commandRouter.getUIConfigOnPlugin('system_hardware', 'touch_display', {})
+  self.commandRouter.getUIConfigOnPlugin('user_interface', 'touch_display', {})
     .then(function (uiconf) {
       self.commandRouter.broadcastMessage('pushUiConfig', uiconf);
     });
@@ -430,19 +430,19 @@ TouchDisplay.prototype.saveBrightnessConf = function (confData) {
         name: self.commandRouter.getI18nString('TOUCH_DISPLAY.TESTBRIGHTNESS'),
         class: 'btn btn-default',
         emit: 'callMethod',
-        payload: { endpoint: 'system_hardware/touch_display', method: 'testBrightness', data: Object.assign({}, confData) }
+        payload: { endpoint: 'user_interface/touch_display', method: 'testBrightness', data: Object.assign({}, confData) }
       },
       {
         name: self.commandRouter.getI18nString('COMMON.CONTINUE'),
         class: 'btn btn-info',
         emit: 'callMethod',
-        payload: { endpoint: 'system_hardware/touch_display', method: 'saveBrightnessConf', data: (function () { const data = Object.assign({}, confData); data.modalResult = true; return data; })() }
+        payload: { endpoint: 'user_interface/touch_display', method: 'saveBrightnessConf', data: (function () { const data = Object.assign({}, confData); data.modalResult = true; return data; })() }
       },
       {
         name: self.commandRouter.getI18nString('COMMON.CANCEL'),
         class: 'btn btn-info',
         emit: 'callMethod',
-        payload: { endpoint: 'system_hardware/touch_display', method: 'saveBrightnessConf', data: (function () { const data = Object.assign({}, confData); data.modalResult = false; return data; })() }
+        payload: { endpoint: 'user_interface/touch_display', method: 'saveBrightnessConf', data: (function () { const data = Object.assign({}, confData); data.modalResult = false; return data; })() }
       }
     ]
   };
@@ -886,13 +886,13 @@ TouchDisplay.prototype.testBrightness = function (confData) {
         name: self.commandRouter.getI18nString('TOUCH_DISPLAY.YES'),
         class: 'btn btn-info',
         emit: 'callMethod',
-        payload: { endpoint: 'system_hardware/touch_display', method: 'saveBrightnessConf', data: (function () { const data = Object.assign({}, confData); data.modalResult = true; return data; })() }
+        payload: { endpoint: 'user_interface/touch_display', method: 'saveBrightnessConf', data: (function () { const data = Object.assign({}, confData); data.modalResult = true; return data; })() }
       },
       {
         name: self.commandRouter.getI18nString('TOUCH_DISPLAY.NO'),
         class: 'btn btn-default',
         emit: 'callMethod',
-        payload: { endpoint: 'system_hardware/touch_display', method: 'saveBrightnessConf', data: (function () { const data = Object.assign({}, confData); data.modalResult = false; return data; })() }
+        payload: { endpoint: 'user_interface/touch_display', method: 'saveBrightnessConf', data: (function () { const data = Object.assign({}, confData); data.modalResult = false; return data; })() }
       }
     ]
   };
@@ -1154,19 +1154,19 @@ TouchDisplay.prototype.getAlsValue = function (data) {
       name: self.commandRouter.getI18nString('TOUCH_DISPLAY.OK'),
       class: 'btn btn-default',
       emit: 'callMethod',
-      payload: { endpoint: 'system_hardware/touch_display', method: 'assignCurrentAls', data: { confData: data.confData, action: data.action } }
+      payload: { endpoint: 'user_interface/touch_display', method: 'assignCurrentAls', data: { confData: data.confData, action: data.action } }
     },
     {
       name: self.commandRouter.getI18nString('TOUCH_DISPLAY.SKIP'),
       class: 'btn btn-info',
       emit: 'callMethod',
-      payload: { endpoint: 'system_hardware/touch_display', method: 'getAlsValue', data: { confData: data.confData, action: data.action.slice(3) } }
+      payload: { endpoint: 'user_interface/touch_display', method: 'getAlsValue', data: { confData: data.confData, action: data.action.slice(3) } }
     },
     {
       name: self.commandRouter.getI18nString('COMMON.CANCEL'),
       class: 'btn btn-info',
       emit: 'callMethod',
-      payload: { endpoint: 'system_hardware/touch_display', method: 'assignCurrentAls', data: { confData: data.confData, action: 'cancel' } }
+      payload: { endpoint: 'user_interface/touch_display', method: 'assignCurrentAls', data: { confData: data.confData, action: 'cancel' } }
     }
   ];
 
@@ -1176,13 +1176,13 @@ TouchDisplay.prototype.getAlsValue = function (data) {
         name: self.commandRouter.getI18nString('TOUCH_DISPLAY.OK'),
         class: 'btn btn-default',
         emit: 'callMethod',
-        payload: { endpoint: 'system_hardware/touch_display', method: 'assignCurrentAls', data: { confData: data.confData, action: data.action } }
+        payload: { endpoint: 'user_interface/touch_display', method: 'assignCurrentAls', data: { confData: data.confData, action: data.action } }
       },
       {
         name: self.commandRouter.getI18nString('COMMON.CANCEL'),
         class: 'btn btn-info',
         emit: 'callMethod',
-        payload: { endpoint: 'system_hardware/touch_display', method: 'assignCurrentAls', data: { confData: data.confData, action: 'cancel' } }
+        payload: { endpoint: 'user_interface/touch_display', method: 'assignCurrentAls', data: { confData: data.confData, action: 'cancel' } }
       }
     ];
   }

--- a/touch_display/package.json
+++ b/touch_display/package.json
@@ -8,7 +8,7 @@
 	},
 	"author": "Volumio Team, gvolt",
 	"license": "ISC",
-	"repository": "https://github.com/volumio/volumio-plugins-sources/touch_display",
+	"repository": "https://github.com/volumio/volumio-plugins-sources/tree/master/touch_display",
 	"volumio_info": {
 		"prettyName": "Touch Display",
 		"icon": "fa-hand-pointer-o",

--- a/touch_display/package.json
+++ b/touch_display/package.json
@@ -1,37 +1,35 @@
 {
 	"name": "touch_display",
-	"version": "3.0.2",
-	"description": "The plugin enables the touch display controller for the original Raspberry 7\" touchscreen.",
+	"version": "3.3.1",
+	"description": "The plugin enables displaying and operating Volumios UI on a original Raspberry 7\" touchscreen.",
 	"main": "index.js",
-	"repository": "http://github.com/yourproject",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
 	"author": "Volumio Team, gvolt",
 	"license": "ISC",
+	"repository": "https://github.com/volumio/volumio-plugins-sources/touch_display",
 	"volumio_info": {
-		"prettyName": "Touch display",
-		"variants": "volumio",
+		"prettyName": "Touch Display",
+		"icon": "fa-hand-pointer-o",
 		"plugin_type": "system_hardware",
-		"os": [
-			"buster"
-		],
-		"changelog": "Volumio3 version",
-		"details": "Touch_display",
-		"channel": "stable",
 		"architectures": [
 			"armhf"
 		],
-		"icon": "fa-hand-pointer-o"
+		"os": [
+			"buster"
+		],
+		"details": "<h4>Touch Display Plugin</h4><br>The plugin enables the display of Volumio's UI on locally connected screens. If the screen offers touch control, apart from keyboard input the UI can be operated from the screen.<br>The plugin focuses on the Raspberry Pi Foundation's 7\" display (and compatible DSI displays), but can in principle also be used with displays connected via HDMI or GPIO. However, HDMI and GPIO displays usually require additional action by the user, depending on the type of display and any touch controller present, and <b>requiring advanced knowledge</b>.",
+		"changelog": "All sync functions now wrapped in \"try ... catch\"; more reliable method to determine the device Volumio is running on"
+	},
+	"engines": {
+		"node": ">=8",
+		"volumio": ">=3"
 	},
 	"dependencies": {
 		"fs-extra": "^8.1.0",
 		"kew": "^0.7.0",
 		"v-conf": "^1.4.2",
 		"socket.io-client": "^2.3.1"
-	},
-	"engines": {
-		"node": ">=8",
-		"volumio": ">=3"
 	}
 }

--- a/touch_display/package.json
+++ b/touch_display/package.json
@@ -12,7 +12,7 @@
 	"volumio_info": {
 		"prettyName": "Touch Display",
 		"icon": "fa-hand-pointer-o",
-		"plugin_type": "system_hardware",
+		"plugin_type": "user_interface",
 		"architectures": [
 			"armhf"
 		],


### PR DESCRIPTION
Remaining "sync" functions have been wrapped into "try ... catch" so the plugin should now pass the requirements of the recently published plugin submission checklist.

Also the plugin now uses a more reliable method to determine the device Volumio is running on.

The version number was adjusted to the versioning of the Volumio 2 plugin. In comparison I upped the minor version to ".1" because of the described changes.


**Note:** I did not run "volumio plugin submit" for this commit.

**Please notify me, if we are supposed to use "volumio plugin submit" in case one wants to get a new version of a plugin merged that is already available from the plugin store.**