### PR TITLE
Touch Display 3.3.1: Update to meet requirements of plugin submission checklist

### DIFF
--- a/touch_display/README.md
+++ b/touch_display/README.md
@@ -1,0 +1,33 @@
+# Touch Display plugin
+
+The plugin enables the display of Volumio's UI on locally connected screens. If the screen offers touch control, apart from keyboard input the UI can be operated from the screen. The plugin focuses on the original Raspberry Pi Foundation 7" display (and compatible DSI displays), but can in principle also be used with displays connected via HDMI or GPIO. However, HDMI and GPIO displays usually require additional action by the user, depending on the type of display and any touch controller present, and **requiring advanced knowledge**.
+
+The following features are available on the plugin’s configuration page (other screens than the the original Raspberry Pi Foundation display may not have all of them available):
+
+## Screen saver
+The options allow setting the timeout in seconds until the screen saver (DPMS state “off”) gets invoked. A value of 0 disables the screen saver.
+Furthermore it is possible to block the screen saver as long as Volumio is in playing state.
+
+## Screen brightness
+For the Raspberry Foundation 7" display the screen brightness can be set. If the current screen brightness should be above 14 and then set to a value below 15 a modal shows up to warn for a very dark screen. The modal offers to test the new (low) value by applying it for 5 seconds before the previous brightness gets restored. After that the user can decide if the new or the previous setting should be kept.
+
+It is possible to define two different brightness values ("brightness 1" and "brightness 2") and to specify the time of day at which each brightness value should be set (e.g. a higher brightness value in the daytime starting at 6:00 and a lower brightness at the night-time starting at 21:00). The time of day values need to follow the 24-hour clock system and the time format hh:mm. If both time of day settings should be identical, the screen brightness will not be changed but only brightness 1 will be applied. Regarding the time values be aware that the plugin uses the system time. The system time might deviate from the local time and can only be changed from the command line currently.
+
+The plugin is also prepared for automatic brightness regulation. The option to use automatic brightness regulation will only show up on the plugin’s configuration page if a file named "/etc/als" exists.
+
+Obviously automatic brightness requires additional hardware in the shape of an ambient light sensor. This is typically an LDR with a voltage divider connected to an ADC like the TI ADS1115. For example if the LDR would be connected to input AIN0 of an ADS1115 measuring single-ended signals in continuous conversion mode the current converted LDR value would appear in "/sys/devices/platform/soc/fe804000.i2c/i2c-1/1-0048/iio:device0/in_voltage0_raw". This file would need to be symlinked to "/etc/als" as the plugin awaits the current value of an ambient light sensor in "/etc/als".
+
+When automatic brightness gets enabled for the first time the light sensor obligatorily has to be “calibrated” according to minimum and maximum screen brightness. The calibration process consists of measuring the ambient light in a first setting (e.g. darkness or twilight) where the lowest screen brightness should be reached and a second setting (e.g. “normal” daylight or bright sunshine) where the highest screen brightness should be reached. Through a dedicated button the calibration process can be repeated anytime if needed. The range of possible screen brightness values can be adjusted through the minimum and maximum screen brightness settings.
+
+Furthermore when using automatic brightness it is possible to define a third “reference” point to form a brightness curve between minimum and maximum screen brightness reaching a “reference” screen brightness at a certain ambient brightness. This can be useful if the progression of screen brightness in accordance to ambient brightness needs to be slowed down or accelerated.
+
+## Display orientation
+The display can be rotated in 90° steps. For the Raspberry Foundation 7" screen the touch direction is rotated accordingly to the display. In principle this works for other screens, too. Depending on the screen additional action might be necessary if ex-factory the X- and/or Y-axis should be inverted and/or the touch function should not be aligned to the display. As there are a lot of different screens in the market with a lot of different ex-factory settings, the plugin does not take care for these partially weird deviations from a screen with display and touch equally rotated and aligned.
+
+When the display orientation setting is changed a modal shows up to inform about a reboot is required. The user has the option to initiate the reboot or proceed (and reboot later).
+
+## GPU memory
+The plugin can control the amount of memory used by the GPU. This setting had to be introduced, because rotating the display by 90° or 270° on a screen with higher resolution requires more GPU memory than 32MB which is the default setting of Volumio. E.g. for a screen with a resolution of 1980x1080 pixels a GPU memory of 34MB has to be set or the screen will stay black.
+
+## Show/hide mouse pointer
+Self explanatory. By default the mouse pointer is hidden.

--- a/touch_display/UIConfig.json
+++ b/touch_display/UIConfig.json
@@ -10,7 +10,7 @@
                 "description": "TRANSLATE.TOUCH_DISPLAY.SCREENSAVER_DESC",
                 "icon": "fa-clock-o",
                 "hidden": "false",
-                "onSave": {"type":"controller", "endpoint":"system_hardware/touch_display", "method":"saveScreensaverConf"},
+                "onSave": {"type":"controller", "endpoint":"user_interface/touch_display", "method":"saveScreensaverConf"},
                 "saveButton": {
                               "label": "TRANSLATE.TOUCH_DISPLAY.APPLY",
                               "data": [
@@ -49,7 +49,7 @@
                 "description": "TRANSLATE.TOUCH_DISPLAY.BRIGHTNESS_DESC",
                 "icon": "fa-sun-o",
                 "hidden": "false",
-                "onSave": {"type":"controller", "endpoint":"system_hardware/touch_display", "method":"saveBrightnessConf"},
+                "onSave": {"type":"controller", "endpoint":"user_interface/touch_display", "method":"saveBrightnessConf"},
                 "saveButton": {
                               "label": "TRANSLATE.TOUCH_DISPLAY.APPLY",
                               "data": [
@@ -108,7 +108,7 @@
                              "element": "button",
                              "doc": "TRANSLATE.TOUCH_DISPLAY.CALIBRATION_DOC",
                              "label": "TRANSLATE.TOUCH_DISPLAY.CALIBRATION",
-                             "onClick": {"type":"controller", "endpoint":"system_hardware/touch_display", "method":"getAlsValue", "data":{"confData": "", "action": "minmax"}},
+                             "onClick": {"type":"controller", "endpoint":"user_interface/touch_display", "method":"getAlsValue", "data":{"confData": "", "action": "minmax"}},
                              "visibleIf": {"field": "autoMode", "value": true}
                              },
                              {
@@ -139,7 +139,7 @@
                              "element": "button",
                              "doc": "TRANSLATE.TOUCH_DISPLAY.GET_MID_ALS_DOC",
                              "label": "TRANSLATE.TOUCH_DISPLAY.GET_MID_ALS",
-                             "onClick": {"type":"controller", "endpoint":"system_hardware/touch_display", "method":"getAlsValue", "data":{"confData": "", "action": "mid"}},
+                             "onClick": {"type":"controller", "endpoint":"user_interface/touch_display", "method":"getAlsValue", "data":{"confData": "", "action": "mid"}},
                              "visibleIf": {"field": "autoMode", "value": true}
                              },
                              {
@@ -211,7 +211,7 @@
                 "description": "TRANSLATE.TOUCH_DISPLAY.ORIENTATION_DESC",
                 "icon": "fa-compass",
                 "hidden": "false",
-                "onSave": {"type":"controller", "endpoint":"system_hardware/touch_display", "method":"saveOrientationConf"},
+                "onSave": {"type":"controller", "endpoint":"user_interface/touch_display", "method":"saveOrientationConf"},
                 "saveButton": {
                               "label": "TRANSLATE.TOUCH_DISPLAY.APPLY",
                               "data": [
@@ -253,7 +253,7 @@
                 "description": "TRANSLATE.TOUCH_DISPLAY.GPUMEM_DESC",
                 "icon": "fa-microchip",
                 "hidden": "false",
-                "onSave": {"type":"controller", "endpoint":"system_hardware/touch_display", "method":"saveGpuMemConf"},
+                "onSave": {"type":"controller", "endpoint":"user_interface/touch_display", "method":"saveGpuMemConf"},
                 "saveButton": {
                               "label": "TRANSLATE.TOUCH_DISPLAY.APPLY",
                               "data": [
@@ -293,7 +293,7 @@
                 "description": "TRANSLATE.TOUCH_DISPLAY.POINTER_DESC",
                 "icon": "fa-mouse-pointer",
                 "hidden": "false",
-                "onSave": {"type":"controller", "endpoint":"system_hardware/touch_display", "method":"savePointerConf"},
+                "onSave": {"type":"controller", "endpoint":"user_interface/touch_display", "method":"savePointerConf"},
                 "saveButton": {
                               "label": "TRANSLATE.TOUCH_DISPLAY.APPLY",
                               "data": [
@@ -317,7 +317,7 @@
                 "description": "TRANSLATE.TOUCH_DISPLAY.SCALE_DESC",
                 "icon": "fa-expand",
                 "hidden": "false",
-                "onSave": {"type":"controller", "endpoint":"system_hardware/touch_display", "method":"saveScaleConf"},
+                "onSave": {"type":"controller", "endpoint":"user_interface/touch_display", "method":"saveScaleConf"},
                 "saveButton": {
                               "label": "TRANSLATE.TOUCH_DISPLAY.APPLY",
                               "data": [

--- a/touch_display/install.sh
+++ b/touch_display/install.sh
@@ -7,34 +7,34 @@ if grep -q Raspberry /proc/cpuinfo; then # on Raspberry Pi hardware
   wget https://repo.volumio.org/Volumio2/Binaries/arm/libraspberrypi0_0.0.1_all.deb
   wget https://repo.volumio.org/Volumio2/Binaries/arm/raspberrypi-bootloader_0.0.1_all.deb
   wget https://repo.volumio.org/Volumio2/Binaries/arm/raspberrypi-kernel_0.0.1_all.deb
-  sudo dpkg -i libraspberrypi0_0.0.1_all.deb
-  sudo dpkg -i raspberrypi-bootloader_0.0.1_all.deb
-  sudo dpkg -i raspberrypi-kernel_0.0.1_all.deb
+  dpkg -i libraspberrypi0_0.0.1_all.deb
+  dpkg -i raspberrypi-bootloader_0.0.1_all.deb
+  dpkg -i raspberrypi-kernel_0.0.1_all.deb
   rm libraspberrypi0_0.0.1_all.deb
   rm raspberrypi-bootloader_0.0.1_all.deb
   rm raspberrypi-kernel_0.0.1_all.deb
 
   echo "Putting on hold packages for kernel, bootloader and pi lib"
-  sudo apt-mark hold libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel
+  apt-mark hold libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel
 
   echo "Installing Chromium dependencies"
-  sudo apt-get update
-  sudo apt-get -y install
+  apt-get update
+  apt-get -y install
 
   echo "Installing graphical environment"
-  sudo DEBIAN_FRONTEND=noninteractive apt-get -y install xinit xorg openbox
+  DEBIAN_FRONTEND=noninteractive apt-get -y install xinit xorg openbox
   if [ "$ID" = "8" ]; then
-    sudo apt-get -y install xserver-xorg-legacy
+    apt-get -y install xserver-xorg-legacy
   fi
 
   echo "Installing Chromium"
-  sudo apt-get -y install chromium-browser
+  apt-get -y install chromium-browser
 
   echo "Creating /etc/X11/xorg.conf.d dir"
-  sudo mkdir /etc/X11/xorg.conf.d
+  mkdir /etc/X11/xorg.conf.d
 
   echo "Creating Xorg configuration file"
-  sudo echo "# This file is managed by the Touch Display plugin: Do not alter!
+  echo "# This file is managed by the Touch Display plugin: Do not alter!
 # It will be deleted when the Touch Display plugin gets uninstalled.
 Section \"InputClass\"
         Identifier \"Touch rotation\"
@@ -44,36 +44,36 @@ Section \"InputClass\"
 EndSection" > /etc/X11/xorg.conf.d/95-touch_display-plugin.conf
 else # on other hardware
   echo "Installing Chromium dependencies"
-  sudo apt-get update
-  sudo apt-get -y install
+  apt-get update
+  apt-get -y install
 
   echo "Installing graphical environment"
-  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y xinit xorg openbox
+  DEBIAN_FRONTEND=noninteractive apt-get install -y xinit xorg openbox
 
   echo "Installing Chromium"
   if [ "$ID" = "8" ]; then
     cd /home/volumio/
     wget https://launchpadlibrarian.net/234969703/chromium-browser_48.0.2564.82-0ubuntu0.15.04.1.1193_armhf.deb
     wget https://launchpadlibrarian.net/234969705/chromium-codecs-ffmpeg-extra_48.0.2564.82-0ubuntu0.15.04.1.1193_armhf.deb
-    sudo dpkg -i /home/volumio/chromium-*.deb
-    sudo apt-get install -y -f
-    sudo dpkg -i /home/volumio/chromium-*.deb
+    dpkg -i /home/volumio/chromium-*.deb
+    apt-get install -y -f
+    dpkg -i /home/volumio/chromium-*.deb
     rm /home/volumio/chromium-*.deb
   else
-    sudo apt-get -y install chromium
-    sudo ln -s /usr/bin/chromium /usr/bin/chromium-browser
+    apt-get -y install chromium
+    ln -s /usr/bin/chromium /usr/bin/chromium-browser
   fi
 fi
 
 echo "Installing japanese, korean, chinese and taiwanese fonts"
-sudo apt-get -y install fonts-arphic-ukai fonts-arphic-gbsn00lp fonts-unfonts-core
+apt-get -y install fonts-arphic-ukai fonts-arphic-gbsn00lp fonts-unfonts-core
 
 echo "Creating Kiosk data dir"
 mkdir /data/volumiokiosk
 chown volumio:volumio /data/volumiokiosk
 
 echo "Creating chromium kiosk start script"
-sudo echo "#!/bin/bash
+echo "#!/bin/bash
 while true; do timeout 3 bash -c \"</dev/tcp/127.0.0.1/3000\" >/dev/null 2>&1 && break; done
 sed -i 's/\"exited_cleanly\":false/\"exited_cleanly\":true/' /data/volumiokiosk/Default/Preferences
 sed -i 's/\"exit_type\":\"Crashed\"/\"exit_type\":\"None\"/' /data/volumiokiosk/Default/Preferences
@@ -98,10 +98,10 @@ while true; do
     --user-data-dir='/data/volumiokiosk' \
     http://localhost:3000
 done" > /opt/volumiokiosk.sh
-sudo /bin/chmod +x /opt/volumiokiosk.sh
+/bin/chmod +x /opt/volumiokiosk.sh
 
 echo "Creating Systemd Unit for Kiosk"
-sudo echo "[Unit]
+echo "[Unit]
 Description=Volumio Kiosk
 Wants=volumio.service
 After=volumio.service
@@ -113,10 +113,10 @@ ExecStart=/usr/bin/startx /etc/X11/Xsession /opt/volumiokiosk.sh -- -nocursor
 [Install]
 WantedBy=multi-user.target
 " > /lib/systemd/system/volumio-kiosk.service
-sudo systemctl daemon-reload
+systemctl daemon-reload
 
 echo "Allowing volumio to start an xsession"
-sudo /bin/sed -i "s/allowed_users=console/allowed_users=anybody/" /etc/X11/Xwrapper.config
+/bin/sed -i "s/allowed_users=console/allowed_users=anybody/" /etc/X11/Xwrapper.config
 
 #required to end the plugin install
 echo "plugininstallend"

--- a/touch_display/package-lock.json
+++ b/touch_display/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "touch_display",
-	"version": "3.0.0",
+	"version": "3.3.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -20,9 +20,9 @@
 			"integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
 		},
 		"base64-arraybuffer": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-			"integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+			"integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI="
 		},
 		"blob": {
 			"version": "0.0.5",
@@ -35,23 +35,49 @@
 			"integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
 		},
 		"component-emitter": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
 		},
 		"component-inherit": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
 			"integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
 		},
+		"debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"engine.io-client": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.2.tgz",
+			"integrity": "sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==",
+			"requires": {
+				"component-emitter": "~1.3.0",
+				"component-inherit": "0.0.3",
+				"debug": "~3.1.0",
+				"engine.io-parser": "~2.2.0",
+				"has-cors": "1.1.0",
+				"indexof": "0.0.1",
+				"parseqs": "0.0.6",
+				"parseuri": "0.0.6",
+				"ws": "~7.4.2",
+				"xmlhttprequest-ssl": "~1.6.2",
+				"yeast": "0.1.2"
+			}
+		},
 		"engine.io-parser": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
-			"integrity": "sha512-6I3qD9iUxotsC5HEMuuGsKA0cXerGz+4uGcXQEkfBidgKf0amsjrrtwcbwK/nzpZBxclXlV7gGl9dgWvu4LF6w==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
+			"integrity": "sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==",
 			"requires": {
 				"after": "0.8.2",
 				"arraybuffer.slice": "~0.0.7",
-				"base64-arraybuffer": "0.1.5",
+				"base64-arraybuffer": "0.1.4",
 				"blob": "0.0.5",
 				"has-binary2": "~1.0.2"
 			}
@@ -67,9 +93,9 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+			"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
 		},
 		"has-binary2": {
 			"version": "1.0.3",
@@ -112,10 +138,25 @@
 			"resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
 			"integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s="
 		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
 		"multimap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/multimap/-/multimap-1.0.2.tgz",
-			"integrity": "sha1-aqdvwyM5BbqUi75MdNwsOgNW6zY="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/multimap/-/multimap-1.0.1.tgz",
+			"integrity": "sha1-/2cUQf2V8lTtdUZqLzEhwE7Sz18="
+		},
+		"parseqs": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+			"integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w=="
+		},
+		"parseuri": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+			"integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow=="
 		},
 		"slide": {
 			"version": "1.1.6",
@@ -138,84 +179,16 @@
 				"parseuri": "0.0.6",
 				"socket.io-parser": "~3.3.0",
 				"to-array": "0.1.4"
-			},
-			"dependencies": {
-				"component-emitter": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-					"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
-				},
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"engine.io-client": {
-					"version": "3.5.1",
-					"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.1.tgz",
-					"integrity": "sha512-oVu9kBkGbcggulyVF0kz6BV3ganqUeqXvD79WOFKa+11oK692w1NyFkuEj4xrkFRpZhn92QOqTk4RQq5LiBXbQ==",
-					"requires": {
-						"component-emitter": "~1.3.0",
-						"component-inherit": "0.0.3",
-						"debug": "~3.1.0",
-						"engine.io-parser": "~2.2.0",
-						"has-cors": "1.1.0",
-						"indexof": "0.0.1",
-						"parseqs": "0.0.6",
-						"parseuri": "0.0.6",
-						"ws": "~7.4.2",
-						"xmlhttprequest-ssl": "~1.5.4",
-						"yeast": "0.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				},
-				"parseqs": {
-					"version": "0.0.6",
-					"resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
-					"integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w=="
-				},
-				"parseuri": {
-					"version": "0.0.6",
-					"resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
-					"integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow=="
-				},
-				"ws": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
-					"integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw=="
-				}
 			}
 		},
 		"socket.io-parser": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
-			"integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.2.tgz",
+			"integrity": "sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==",
 			"requires": {
-				"component-emitter": "1.2.1",
+				"component-emitter": "~1.3.0",
 				"debug": "~3.1.0",
 				"isarray": "2.0.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				}
 			}
 		},
 		"to-array": {
@@ -229,28 +202,29 @@
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
 		},
 		"v-conf": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/v-conf/-/v-conf-1.4.2.tgz",
-			"integrity": "sha512-oYeoOJipFmGIhabjAdGUXyml+WZD1+fLPvOudRHo2ny9zsx39XpzwzeqOh0kmGyIyJqSPg60hFTh4OJBcyEATQ==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/v-conf/-/v-conf-1.4.3.tgz",
+			"integrity": "sha512-jhnAhXDbzorq3pkoqrOzbiLP0yO4rxlfmWUvUuffDM6Dz6YZRN/LfzS1WmvJOFeq8CWapLRyO2std/U2VsOpBg==",
 			"requires": {
-				"fs-extra": "2.1.2",
-				"multimap": "1.0.2",
+				"fs-extra": "^3.0.1",
+				"multimap": "1.0.1",
 				"write-file-atomic": "1.3.1"
 			},
 			"dependencies": {
 				"fs-extra": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-					"integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+					"integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
 					"requires": {
 						"graceful-fs": "^4.1.2",
-						"jsonfile": "^2.1.0"
+						"jsonfile": "^3.0.0",
+						"universalify": "^0.1.0"
 					}
 				},
 				"jsonfile": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+					"integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
 					"requires": {
 						"graceful-fs": "^4.1.6"
 					}
@@ -267,10 +241,15 @@
 				"slide": "^1.1.5"
 			}
 		},
+		"ws": {
+			"version": "7.4.6",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+			"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
+		},
 		"xmlhttprequest-ssl": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-			"integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
+			"integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q=="
 		},
 		"yeast": {
 			"version": "0.1.2",

--- a/touch_display/package.json
+++ b/touch_display/package.json
@@ -1,37 +1,35 @@
 {
 	"name": "touch_display",
-	"version": "3.0.2",
-	"description": "The plugin enables the touch display controller for the original Raspberry 7\" touchscreen.",
+	"version": "3.3.1",
+	"description": "The plugin enables displaying and operating Volumios UI on a original Raspberry 7\" touchscreen.",
 	"main": "index.js",
-	"repository": "http://github.com/yourproject",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
 	"author": "Volumio Team, gvolt",
 	"license": "ISC",
+	"repository": "https://github.com/volumio/volumio-plugins-sources/tree/master/touch_display",
 	"volumio_info": {
-		"prettyName": "Touch display",
-		"variants": "volumio",
-		"plugin_type": "system_hardware",
-		"os": [
-			"buster"
-		],
-		"changelog": "Volumio3 version",
-		"details": "Touch_display",
-		"channel": "stable",
+		"prettyName": "Touch Display",
+		"icon": "fa-hand-pointer-o",
+		"plugin_type": "user_interface",
 		"architectures": [
 			"armhf"
 		],
-		"icon": "fa-hand-pointer-o"
-	},
-	"dependencies": {
-		"fs-extra": "^8.1.0",
-		"kew": "^0.7.0",
-		"v-conf": "^1.4.2",
-		"socket.io-client": "^2.3.1"
+		"os": [
+			"buster"
+		],
+		"details": "<h4>Touch Display Plugin</h4><br>The plugin enables the display of Volumio's UI on locally connected screens. If the screen offers touch control, apart from keyboard input the UI can be operated from the screen.<br>The plugin focuses on the Raspberry Pi Foundation's 7\" display (and compatible DSI displays), but can in principle also be used with displays connected via HDMI or GPIO. However, HDMI and GPIO displays usually require additional action by the user, depending on the type of display and any touch controller present, and <b>requiring advanced knowledge</b>.",
+		"changelog": "Changed plugin type to \"user_interface\"; all sync functions now wrapped in \"try ... catch\"; more reliable method to determine the device Volumio is running on"
 	},
 	"engines": {
 		"node": ">=8",
 		"volumio": ">=3"
+	},
+	"dependencies": {
+		"fs-extra": "^8.1.0",
+		"kew": "^0.7.0",
+		"v-conf": "^1.4.3",
+		"socket.io-client": "^2.3.1"
 	}
 }

--- a/touch_display/uninstall.sh
+++ b/touch_display/uninstall.sh
@@ -4,33 +4,33 @@ HW=$(awk '/VOLUMIO_HARDWARE=/' /etc/*-release | sed 's/VOLUMIO_HARDWARE=//' | se
 ID=$(awk '/VERSION_ID=/' /etc/*-release | sed 's/VERSION_ID=//' | sed 's/\"//g')
 
 echo "Removing dependencies"
-sudo apt-get -y purge --auto-remove fonts-arphic-ukai fonts-arphic-gbsn00lp fonts-unfonts-core
+apt-get -y purge --auto-remove fonts-arphic-ukai fonts-arphic-gbsn00lp fonts-unfonts-core
 if [ "$HW" = "pi" ]; then # on Raspberry Pi hardware
-  sudo apt-mark unhold libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel
-  sudo apt-get -y purge --auto-remove chromium-browser openbox xinit libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel
+  apt-mark unhold libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel
+  apt-get -y purge --auto-remove chromium-browser openbox xinit libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel
   if [ "$ID" = "8" ]; then
-    sudo apt-get -y purge --auto-remove xserver-xorg-legacy
+    apt-get -y purge --auto-remove xserver-xorg-legacy
   fi
 else # on other hardware
   if [ "$ID" = "8" ]; then
-    sudo apt-get -y purge --auto-remove chromium-codecs-ffmpeg-extra chromium-browser openbox xinit
+    apt-get -y purge --auto-remove chromium-codecs-ffmpeg-extra chromium-browser openbox xinit
   else
-    sudo apt-get -y purge --auto-remove chromium openbox xinit
+    apt-get -y purge --auto-remove chromium openbox xinit
   fi
 fi
 
 echo "Deleting /opt/volumiokiosk.sh"
-sudo rm /opt/volumiokiosk.sh
+rm /opt/volumiokiosk.sh
 
 echo "Deleting /data/volumiokiosk"
-sudo rm -rf /data/volumiokiosk
+rm -rf /data/volumiokiosk
 
 echo "Deleting /lib/systemd/system/volumio-kiosk.service"
-sudo rm /lib/systemd/system/volumio-kiosk.service
+rm /lib/systemd/system/volumio-kiosk.service
 
 if [ -f /etc/X11/xorg.conf.d/95-touch_display-plugin.conf ]; then
   echo "Deleting /etc/X11/xorg.conf.d/95-touch_display-plugin.conf"
-  sudo rm /etc/X11/xorg.conf.d/95-touch_display-plugin.conf
+  rm /etc/X11/xorg.conf.d/95-touch_display-plugin.conf
 fi
 
 echo "Done"


### PR DESCRIPTION
According to the [docs](https://volumio-developers-docs.vercel.app/plugins/plugins-overview#user_interface) plugin type has been changed to "user_interface".

Remaining "sync" functions have been wrapped into "try ... catch" so the plugin should now pass the requirements of the recently published plugin submission checklist.

Also the plugin now uses a more reliable method to determine the device Volumio is running on.

The version number was adjusted to the versioning of the Volumio 2 plugin. In comparison I upped the minor version to ".1" because of the described changes.

**Note:** I ran "volumio plugin submit" for this commit but received `Error adding plugin: Error: got 401 response`. Is there a way to solve the problem?