### PR TITLE
set new status to correct variable, before pushing the state

### DIFF
--- a/volspotconnect2/index.js
+++ b/volspotconnect2/index.js
@@ -693,7 +693,7 @@ ControllerVolspotconnect.prototype.play = function () {
   if (this.active) {
     return this.spotifyApi.play().then(e => {
       if (this.state.status !== 'play') {
-        this.state.staus = 'play';
+        this.state.status = 'play';
         this.pushState();
       }
     }).catch(error => {


### PR DESCRIPTION
Fixes pushing wrong state to clients?