### PR TITLE
Update Bandcamp Discover plugin 0.1.3

### DIFF
--- a/bandcamp/README.md
+++ b/bandcamp/README.md
@@ -22,6 +22,11 @@ As the name implies, the purpose of this plugin is to allow you to discover musi
 
 ## Changelog
 
+0.1.3
+- Fixed adding current track to playlist / favorites in Playback view
+- Because of fix above, track info now shows bitrate (as obtained by MPD) instead of bit depth and sample rate
+- If Manifest UI is enabled, titles will be shown in plain text without formatting and links. For Bandcamp Daily, article texts will be hidden as they will not display nicely in Manifest UI's page anchors.
+
 0.1.2
 - Display search results by item type (configurable in plugin settings)
 

--- a/bandcamp/i18n/strings_en.json
+++ b/bandcamp/i18n/strings_en.json
@@ -59,6 +59,7 @@
   "BANDCAMP_VIEW_LINK_LABEL": "View this label on Bandcamp",
   "BANDCAMP_VIEW_LINK_SHOW": "Listen to this show on Bandcamp",
   "BANDCAMP_VIEW_LINK_ARTICLE": "View article on Bandcamp",
+  "BANDCAMP_UI_CONTENT_HIDDEN": "(Manifest UI enabled - content hidden)",
   "BANDCAMP_SECTION_GENERAL": "General Settings",
   "BANDCAMP_ITEMS_PER_PAGE": "Items per page",
   "BANDCAMP_COMBINED_SEARCH_RESULTS": "Items in combined search results",

--- a/bandcamp/index.js
+++ b/bandcamp/index.js
@@ -187,6 +187,14 @@ ControllerBandcamp.prototype.seek = function (position) {
     return this.playController.seek(position);
 }
 
+ControllerBandcamp.prototype.next = function () {
+    return this.playController.next();
+}
+
+ControllerBandcamp.prototype.previous = function () {
+    return this.playController.previous();
+}
+
 ControllerBandcamp.prototype.search = function(query) {
     return this.searchController.search(query);
 }

--- a/bandcamp/lib/controller/browse/view-handlers/article.js
+++ b/bandcamp/lib/controller/browse/view-handlers/article.js
@@ -180,7 +180,7 @@ class ArticleViewHandler extends ExplodableViewHandler {
 
         return self._getCategoryFromUriOrDefault().then( (currentCategory) => {
             let firstList = {
-                title: UIHelper.addIconBefore('fa fa-filter', bandcamp.getI18n('BANDCAMP_ARTICLE_CATEGORIES')),
+                title: UIHelper.addIconToListTitle('fa fa-filter', bandcamp.getI18n('BANDCAMP_ARTICLE_CATEGORIES')),
                 availableListViews: ['list'],
                 items: []
             };
@@ -375,6 +375,10 @@ class ArticleViewHandler extends ExplodableViewHandler {
             }
             else {
                 title = UIHelper.wrapInDiv(title, 'width: 100%;');
+            }
+
+            if (!UIHelper.supportsEnhancedTitles()) {
+                title = bandcamp.getI18n('BANDCAMP_UI_CONTENT_HIDDEN');
             }
 
             lists.push({

--- a/bandcamp/lib/controller/browse/view-handlers/discover.js
+++ b/bandcamp/lib/controller/browse/view-handlers/discover.js
@@ -159,6 +159,17 @@ class DiscoverViewHandler extends BaseViewHandler {
 
         let title = UIHelper.constructListTitleWithLink(UIHelper.addBandcampIconToListTitle(bandcamp.getI18n(view.inSection ? 'BANDCAMP_DISCOVER_SHORT' : 'BANDCAMP_DISCOVER')), links, true);
 
+        if (!UIHelper.supportsEnhancedTitles()) {
+            // Compensate for loss of 'browse by tags' link
+            let browseByTagsLinkData = this._getBrowseByTagsLinkData();
+            items.push({
+                type: 'bandcampLinkItem',
+                uri: browseByTagsLinkData.uri,
+                title: browseByTagsLinkData.text,
+                icon: 'fa fa-arrow-circle-right'
+            });
+        }
+
         return {
             title,
             availableListViews: ['list'],
@@ -167,13 +178,11 @@ class DiscoverViewHandler extends BaseViewHandler {
     }
 
     _getBrowseByTagsLink() {
-        let baseUri = this.getUri();
-        let gotoPath = baseUri + '/tag';
-        let gotoText = bandcamp.getI18n('BANDCAMP_BROWSE_BY_TAGS');
+        let linkData = this._getBrowseByTagsLinkData();
         let gotoLink = {
             url: '#',
-            text: gotoText,
-            onclick: 'angular.element(\'#browse-page\').scope().browse.fetchLibrary({uri: \'' + gotoPath + '\'})',
+            text: linkData.text,
+            onclick: 'angular.element(\'#browse-page\').scope().browse.fetchLibrary({uri: \'' + linkData.uri + '\'})',
             icon: {
                 type: 'fa',
                 class: 'fa fa-arrow-circle-right',
@@ -182,6 +191,13 @@ class DiscoverViewHandler extends BaseViewHandler {
             }
         };
         return gotoLink;
+    }
+
+    _getBrowseByTagsLinkData() {
+        return {
+            uri: this.getUri() + '/tag',
+            text: bandcamp.getI18n('BANDCAMP_BROWSE_BY_TAGS')
+        }
     }
 
     _getAlbumsList(albums) {
@@ -233,7 +249,7 @@ class DiscoverViewHandler extends BaseViewHandler {
                 });
             });
             let title = bandcamp.getI18n(`BANDCAMP_SELECT_${view.select.toUpperCase()}`);
-            title = UIHelper.addIconBefore(DISCOVER_OPTION_ICONS[view.select], title);
+            title = UIHelper.addIconToListTitle(DISCOVER_OPTION_ICONS[view.select], title);
             let lists = [{
                 title,
                 availableListViews: ['list'],

--- a/bandcamp/lib/controller/browse/view-handlers/show.js
+++ b/bandcamp/lib/controller/browse/view-handlers/show.js
@@ -100,10 +100,14 @@ class ShowViewHandler extends ExplodableViewHandler {
             if (view.view === 'albums') {
                 let albumParser = self.getParser('album');
                 let trackParser = self.getParser('track');
+                let switchViewLinkData = {
+                    uri: self._constructUriWithParams({ view: 'tracks', noExplode: 1 }),
+                    text: bandcamp.getI18n('BANDCAMP_SHOW_FEATURED_TRACKS')
+                };
                 let switchViewLink = {
                     url: '#',
-                    text: bandcamp.getI18n('BANDCAMP_SHOW_FEATURED_TRACKS'),
-                    onclick: 'angular.element(\'#browse-page\').scope().browse.fetchLibrary({uri: \'' + self._constructUriWithParams({ view: 'tracks', noExplode: 1 }) + '\'}, true)',
+                    text: switchViewLinkData.text,
+                    onclick: 'angular.element(\'#browse-page\').scope().browse.fetchLibrary({uri: \'' + switchViewLinkData.uri + '\'}, true)',
                     icon: {
                         type: 'fa',
                         class: 'fa fa-arrow-circle-right',
@@ -147,6 +151,8 @@ class ShowViewHandler extends ExplodableViewHandler {
                         }
                     });
                     data.lists.push(featuredAlbumsSection);
+                    self._checkAndAddSwitchViewListItem(switchViewLinkData, data.lists);
+
                     return data;
                 }).fail( (error) => {
                     /*console.log(error);
@@ -156,10 +162,14 @@ class ShowViewHandler extends ExplodableViewHandler {
             }
             else {
                 let trackParser = self.getParser('track');
+                let switchViewLinkData = {
+                    uri: self._constructUriWithParams({ view: 'albums', noExplode: 1 }),
+                    text: bandcamp.getI18n('BANDCAMP_SHOW_TRACK_SOURCES')
+                };
                 let switchViewLink = {
                     url: '#',
-                    text: bandcamp.getI18n('BANDCAMP_SHOW_TRACK_SOURCES'),
-                    onclick: 'angular.element(\'#browse-page\').scope().browse.fetchLibrary({uri: \'' + self._constructUriWithParams({ view: 'albums', noExplode: 1 }) + '\'}, true)',
+                    text: switchViewLinkData.text,
+                    onclick: 'angular.element(\'#browse-page\').scope().browse.fetchLibrary({uri: \'' + switchViewLinkData.uri + '\'}, true)',
                     icon: {
                         type: 'fa',
                         class: 'fa fa-arrow-circle-right',
@@ -187,6 +197,8 @@ class ShowViewHandler extends ExplodableViewHandler {
                         featuredTracksSection.items.push(trackParser.parseToListItem(track));
                     });
                     data.lists.push(featuredTracksSection);
+                    self._checkAndAddSwitchViewListItem(switchViewLinkData, data.lists);
+
                     return data;
                 }).fail( (error) => {
                     /*console.log(error);
@@ -220,6 +232,23 @@ class ShowViewHandler extends ExplodableViewHandler {
         let curView = Object.assign({}, this.getCurrentView(), params);
 
         return this.constructUriFromViews(prevViews.concat(curView));
+    }
+
+    _checkAndAddSwitchViewListItem(data, lists) {
+        if (!UIHelper.supportsEnhancedTitles()) {
+            // Compensate for loss of switch view link
+            let switchViewListItem = {
+                type: 'bandcampLinkItem',
+                uri: data.uri,
+                title: data.text,
+                icon: 'fa fa-arrow-circle-right'
+            };
+            lists.push({
+                availableListViews: ['list'],
+                items: [ switchViewListItem ]
+            });
+        }
+        return lists;
     }
 
     getTracksOnExplode() {

--- a/bandcamp/lib/controller/browse/view-handlers/tag.js
+++ b/bandcamp/lib/controller/browse/view-handlers/tag.js
@@ -66,7 +66,7 @@ class TagViewHandler extends ExplodableViewHandler {
         tags[key].forEach( (tag) => {
             items.push(parser.parseToListItem(tag, this._constructTagUrl(tag.url), currentTagUrl));
         });
-        title = UIHelper.addIconBefore(icon, title);
+        title = UIHelper.addIconToListTitle(icon, title);
         return {
             title,
             availableListViews: ['list'],
@@ -241,7 +241,7 @@ class TagViewHandler extends ExplodableViewHandler {
                 });
             }
             let title = bandcamp.getI18n(`BANDCAMP_SELECT_${view.select.toUpperCase()}`);
-            title = UIHelper.addIconBefore(FILTER_ICONS[view.select], title);
+            title = UIHelper.addIconToListTitle(FILTER_ICONS[view.select], title);
             let lists = [{
                 title,
                 availableListViews: ['list'],

--- a/bandcamp/lib/controller/play/index.js
+++ b/bandcamp/lib/controller/play/index.js
@@ -32,23 +32,33 @@ class PlayController {
     }
 
     stop() {
-        bandcamp.getStateMachine().setConsumeUpdateService('mpd', false, false);
+        bandcamp.getStateMachine().setConsumeUpdateService('mpd', true, false);
         return this.mpdPlugin.stop();
     };
 
     pause() {
-        bandcamp.getStateMachine().setConsumeUpdateService('mpd', false, false);
+        bandcamp.getStateMachine().setConsumeUpdateService('mpd', true, false);
         return this.mpdPlugin.pause();
     };
   
     resume() {
-        bandcamp.getStateMachine().setConsumeUpdateService('mpd', false, false);
+        bandcamp.getStateMachine().setConsumeUpdateService('mpd', true, false);
         return this.mpdPlugin.resume();
     }
   
     seek(position) {
-        bandcamp.getStateMachine().setConsumeUpdateService('mpd', false, false);
+        bandcamp.getStateMachine().setConsumeUpdateService('mpd', true, false);
         return this.mpdPlugin.seek(position);
+    }
+
+    next() {
+        bandcamp.getStateMachine().setConsumeUpdateService('mpd', true, false);
+        return this.mpdPlugin.next();
+    }
+
+    previous() {
+        bandcamp.getStateMachine().setConsumeUpdateService(undefined);
+        return bandcamp.getStateMachine().previous();
     }
 
     _getStreamUrl(track) {
@@ -150,7 +160,7 @@ class PlayController {
             }
         })
         .then( () => {
-            bandcamp.getStateMachine().setConsumeUpdateService('mpd', false, false);
+            bandcamp.getStateMachine().setConsumeUpdateService('mpd', true, false);
             return mpdPlugin.sendMpdCommand('play', []);
         });
     }

--- a/bandcamp/lib/helper/ui.js
+++ b/bandcamp/lib/helper/ui.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const bandcamp = require(bandcampPluginLibRoot + '/bandcamp');
+const fs = require('fs');
 
 class UIHelper {
 
@@ -8,10 +9,16 @@ class UIHelper {
         return `<img src="/albumart?sourceicon=${encodeURIComponent('music_service/bandcamp/assets/images/bandcamp.svg')}" style="width: 23px; height: 23px; margin-right: 8px; margin-top: -3px;" />`;
     }
     static addBandcampIconToListTitle(s) {
+        if (!this.supportsEnhancedTitles()) {
+            return s;
+        }
         return `${this.getBandcampIcon()}${s}`;
     }
 
-    static addIconBefore(faClass, s) {
+    static addIconToListTitle(faClass, s) {
+        if (!this.supportsEnhancedTitles()) {
+            return s;
+        }
         return `<i class="${faClass}" style="padding-right: 15px;"></i>${s}`;
     }
 
@@ -36,6 +43,9 @@ class UIHelper {
     }
 
     static constructListTitleWithLink(title, links, isFirstList) {
+        if (!this.supportsEnhancedTitles()) {
+            return title;
+        }
         let html = `<div style="display: flex; width: 100%; align-items: flex-end;${isFirstList ? '' : ' margin-top: -24px;'}">
                     <div>${title}</div>
                     <div style="flex-grow: 1; text-align: right; font-size: small;">`;
@@ -77,6 +87,15 @@ class UIHelper {
         return html;
     }
 
+    static supportsEnhancedTitles() {
+        return !this.isManifestUI();
+    }
+    
+    static isManifestUI() {
+        let volumioManifestUIFlagFile = '/data/manifestUI';
+        let volumioManifestUIDisabledFile = '/data/disableManifestUI';
+        return fs.existsSync(volumioManifestUIFlagFile) && !fs.existsSync(volumioManifestUIDisabledFile);
+    }
 }
 
 UIHelper.STYLES = {

--- a/bandcamp/package.json
+++ b/bandcamp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bandcamp",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "Discover Bandcamp music",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
- Fixed adding current track to playlist / favorites in Playback view
- If Manifest UI is enabled, titles will be shown in plain text without formatting and links. For Bandcamp Daily, article texts will be hidden as they will not display nicely in Manifest UI's page anchors.