### PR TITLE
Issue 67 - Fix podcast popup menu Add to favourites

### DIFF
--- a/podcast/index.js
+++ b/podcast/index.js
@@ -629,7 +629,7 @@ ControllerPodcast.prototype.getPodcastContent = function(uri) {
           var urlParam = JSON.stringify(param);
           var podcastItem = {
             service: self.serviceName,
-            type: 'mywebradio',
+            type: 'song',
             title: entry.title,
             uri: `podcast/${podcastId}/${encodeURIComponent(urlParam)}`
           };


### PR DESCRIPTION
Fix for https://github.com/volumio/volumio-plugins-sources/issues/67

Podcast episodes are getting the same popup as webradio stations, meaning that the menu has an option says "Add to Radio favourites",  even though it actually adds to the regular Favourites. The popup menu also has an option to "Edit Webradio", which doesn't make sense.

This is because the individual episodes have type "mywebradio". Changing the type to "song" gives the episodes the normal popup menu, adds the heart icon as a shortcut to "Add to favourites", and doesn't appear to change any other behaviour.