### PR TITLE
[GPIO Control] Add ability to cancel other delayed events

### DIFF
--- a/gpio_control/UIConfig-OldSchool.json
+++ b/gpio_control/UIConfig-OldSchool.json
@@ -21,6 +21,7 @@
 					"systemStartupState",
 					"systemStartupDelay",
 					"systemStartupDelayUnits",
+					"systemStartupCancelDelayedEvents",
 					"systemStartupDuration",
 					"systemStartupDurationUnits",
 					"systemShutdownEnabled",
@@ -28,6 +29,7 @@
 					"systemShutdownState",
 					"systemShutdownDelay",
 					"systemShutdownDelayUnits",
+					"systemShutdownCancelDelayedEvents",
 					"systemShutdownDuration",
 					"systemShutdownDurationUnits",
 					"musicPlayEnabled",
@@ -35,6 +37,7 @@
 					"musicPlayState",
 					"musicPlayDelay",
 					"musicPlayDelayUnits",
+					"musicPlayCancelDelayedEvents",
 					"musicPlayDuration",
 					"musicPlayDurationUnits",
 					"musicPauseEnabled",
@@ -42,6 +45,7 @@
 					"musicPauseState",
 					"musicPauseDelay",
 					"musicPauseDelayUnits",
+					"musicPauseCancelDelayedEvents",
 					"musicPauseDuration",
 					"musicPauseDurationUnits",
 					"musicStopEnabled",
@@ -49,6 +53,7 @@
 					"musicStopState",
 					"musicStopDelay",
 					"musicStopDelayUnits",
+					"musicStopCancelDelayedEvents",
 					"musicStopDuration",
 					"musicStopDurationUnits"
 				]
@@ -620,6 +625,13 @@
 						"field": "systemStartupEnabled",
 						"value": true
 					}
+				},
+				{
+					"id": "systemStartupCancelDelayedEvents",
+					"element": "switch",
+					"label": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS",
+					"doc": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS_DOC",
+					"value": false
 				},
 				{
 					"id": "systemStartupDuration",
@@ -1641,6 +1653,13 @@
 					}
 				},
 				{
+					"id": "systemShutdownCancelDelayedEvents",
+					"element": "switch",
+					"label": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS",
+					"doc": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS_DOC",
+					"value": false
+				},
+				{
 					"id": "systemShutdownDuration",
 					"element": "select",
 					"label": "TRANSLATE.GPIO_DURATION",
@@ -2658,6 +2677,13 @@
 						"field": "musicPlayEnabled",
 						"value": true
 					}
+				},
+				{
+					"id": "musicPlayCancelDelayedEvents",
+					"element": "switch",
+					"label": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS",
+					"doc": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS_DOC",
+					"value": false
 				},
 				{
 					"id": "musicPlayDuration",
@@ -3679,6 +3705,13 @@
 					}
 				},
 				{
+					"id": "musicPauseCancelDelayedEvents",
+					"element": "switch",
+					"label": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS",
+					"doc": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS_DOC",
+					"value": false
+				},
+				{
 					"id": "musicPauseDuration",
 					"element": "select",
 					"label": "TRANSLATE.GPIO_DURATION",
@@ -4696,6 +4729,13 @@
 						"field": "systemShutdownEnabled",
 						"value": true
 					}
+				},
+				{
+					"id": "musicStopCancelDelayedEvents",
+					"element": "switch",
+					"label": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS",
+					"doc": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS_DOC",
+					"value": false
 				},
 				{
 					"id": "musicStopDuration",

--- a/gpio_control/UIConfig.json
+++ b/gpio_control/UIConfig.json
@@ -21,6 +21,7 @@
 					"systemStartupState",
 					"systemStartupDelay",
 					"systemStartupDelayUnits",
+					"systemStartupCancelDelayedEvents",
 					"systemStartupDuration",
 					"systemStartupDurationUnits",
 					"systemShutdownEnabled",
@@ -28,6 +29,7 @@
 					"systemShutdownState",
 					"systemShutdownDelay",
 					"systemShutdownDelayUnits",
+					"systemShutdownCancelDelayedEvents",
 					"systemShutdownDuration",
 					"systemShutdownDurationUnits",
 					"musicPlayEnabled",
@@ -35,6 +37,7 @@
 					"musicPlayState",
 					"musicPlayDelay",
 					"musicPlayDelayUnits",
+					"musicPlayCancelDelayedEvents",
 					"musicPlayDuration",
 					"musicPlayDurationUnits",
 					"musicPauseEnabled",
@@ -42,6 +45,7 @@
 					"musicPauseState",
 					"musicPauseDelay",
 					"musicPauseDelayUnits",
+					"musicPauseCancelDelayedEvents",
 					"musicPauseDuration",
 					"musicPauseDurationUnits",
 					"musicStopEnabled",
@@ -49,6 +53,7 @@
 					"musicStopState",
 					"musicStopDelay",
 					"musicStopDelayUnits",
+					"musicStopCancelDelayedEvents",
 					"musicStopDuration",
 					"musicStopDurationUnits"
 				]
@@ -652,6 +657,17 @@
 							"label": "TRANSLATE.UNITS_MILLISECONDS"
 						}
 					],
+					"visibleIf": {
+						"field": "systemStartupEnabled",
+						"value": true
+					}
+				},
+				{
+					"id": "systemStartupCancelDelayedEvents",
+					"element": "switch",
+					"label": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS",
+					"doc": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS_DOC",
+					"value": false,
 					"visibleIf": {
 						"field": "systemStartupEnabled",
 						"value": true
@@ -1713,6 +1729,17 @@
 					}
 				},
 				{
+					"id": "systemShutdownCancelDelayedEvents",
+					"element": "switch",
+					"label": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS",
+					"doc": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS_DOC",
+					"value": false,
+					"visibleIf": {
+						"field": "systemShutdownEnabled",
+						"value": true
+					}
+				},
+				{
 					"id": "systemShutdownDuration",
 					"element": "select",
 					"label": "TRANSLATE.GPIO_DURATION",
@@ -2762,6 +2789,17 @@
 							"label": "TRANSLATE.UNITS_MILLISECONDS"
 						}
 					],
+					"visibleIf": {
+						"field": "musicPlayEnabled",
+						"value": true
+					}
+				},
+				{
+					"id": "musicPlayCancelDelayedEvents",
+					"element": "switch",
+					"label": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS",
+					"doc": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS_DOC",
+					"value": false,
 					"visibleIf": {
 						"field": "musicPlayEnabled",
 						"value": true
@@ -3823,6 +3861,17 @@
 					}
 				},
 				{
+					"id": "musicPauseCancelDelayedEvents",
+					"element": "switch",
+					"label": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS",
+					"doc": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS_DOC",
+					"value": false,
+					"visibleIf": {
+						"field": "musicPauseEnabled",
+						"value": true
+					}
+				},
+				{
 					"id": "musicPauseDuration",
 					"element": "select",
 					"label": "TRANSLATE.GPIO_DURATION",
@@ -4873,7 +4922,18 @@
 						}
 					],
 					"visibleIf": {
-						"field": "systemShutdownEnabled",
+						"field": "musicStopEnabled",
+						"value": true
+					}
+				},
+				{
+					"id": "musicStopCancelDelayedEvents",
+					"element": "switch",
+					"label": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS",
+					"doc": "TRANSLATE.GPIO_CANCEL_OTHER_TIMERS_DOC",
+					"value": false,
+					"visibleIf": {
+						"field": "musicStopEnabled",
 						"value": true
 					}
 				},

--- a/gpio_control/config.json
+++ b/gpio_control/config.json
@@ -27,6 +27,10 @@
     "durationUnits": {
       "value": 0,
       "type": "number"
+    },
+    "cancelDelayedEvents": {
+      "value": false,
+      "type": "boolean"
     }
   },
   "systemShutdown": {
@@ -57,6 +61,10 @@
     "durationUnits": {
       "value": 0,
       "type": "number"
+    },
+    "cancelDelayedEvents": {
+      "value": false,
+      "type": "boolean"
     }
   },
   "musicPlay": {
@@ -87,6 +95,10 @@
     "durationUnits": {
       "value": 0,
       "type": "number"
+    },
+    "cancelDelayedEvents": {
+      "value": false,
+      "type": "boolean"
     }
   },
   "musicPause": {
@@ -117,6 +129,10 @@
     "durationUnits": {
       "value": 0,
       "type": "number"
+    },
+    "cancelDelayedEvents": {
+      "value": false,
+      "type": "boolean"
     }
   },
   "musicStop": {
@@ -147,6 +163,10 @@
     "durationUnits": {
       "value": 0,
       "type": "number"
+    },
+    "cancelDelayedEvents": {
+      "value": false,
+      "type": "boolean"
     }
   }
 }

--- a/gpio_control/i18n/strings_en.json
+++ b/gpio_control/i18n/strings_en.json
@@ -24,7 +24,7 @@
 	"GPIO_DELAY_UNITS": "Delay units",
 	"GPIO_DELAY_UNITS_DOC": "Delay units",
 	"GPIO_CANCEL_OTHER_TIMERS": "Cancel existing delayed events",
-	"GPIO_CANCEL_OTHER_TIMERS_DOC": "Whether or not to cancel any existing delayed events still pending",
+	"GPIO_CANCEL_OTHER_TIMERS_DOC": "Cancel any delayed events still pending",
 	"GPIO_DURATION": "Duration",
 	"GPIO_DURATION_DOC": "How long to keep the GPIO at this state",
 	"GPIO_DURATION_UNITS": "Duration units",

--- a/gpio_control/i18n/strings_en.json
+++ b/gpio_control/i18n/strings_en.json
@@ -23,6 +23,8 @@
 	"GPIO_DELAY_DOC": "How long to wait before setting the GPIO state",
 	"GPIO_DELAY_UNITS": "Delay units",
 	"GPIO_DELAY_UNITS_DOC": "Delay units",
+	"GPIO_CANCEL_OTHER_TIMERS": "Cancel existing delayed events",
+	"GPIO_CANCEL_OTHER_TIMERS_DOC": "Whether or not to cancel any existing delayed events still pending",
 	"GPIO_DURATION": "Duration",
 	"GPIO_DURATION_DOC": "How long to keep the GPIO at this state",
 	"GPIO_DURATION_UNITS": "Duration units",

--- a/gpio_control/index.js
+++ b/gpio_control/index.js
@@ -402,7 +402,6 @@ GPIOControl.prototype.cancelAllDelayedEvents = function() {
 	});
 }
 
-
 // Output to log
 GPIOControl.prototype.log = function(s) {
 	var self = this;

--- a/gpio_control/index.js
+++ b/gpio_control/index.js
@@ -353,7 +353,6 @@ GPIOControl.prototype.handleEvent = function(e) {
 	self.GPIOs.forEach(function(gpio) {
 		if (gpio.e == e) {
 
-			self.log(`cancelDelayedEvents: ${gpio.cancelDelayedEvents}`);
 			if (gpio.cancelDelayedEvents) {
 				self.cancelAllDelayedEvents();
 			}
@@ -396,7 +395,7 @@ GPIOControl.prototype.handleEvent = function(e) {
 // Cancel all delayed events
 GPIOControl.prototype.cancelAllDelayedEvents = function() {
 	var self = this;
-	
+
 	// Clear any previous delay timers
 	self.log('Cancelling all previous delayed events');
 	self.GPIOs.forEach(function(gpio) {

--- a/gpio_control/index.js
+++ b/gpio_control/index.js
@@ -405,7 +405,7 @@ GPIOControl.prototype.cancelAllDelayedEvents = function() {
 // Output to log
 GPIOControl.prototype.log = function(s) {
 	var self = this;
-//	self.logger.info("[GPIO_Control] " + s);
+	self.logger.info("[GPIO_Control] " + s);
 }
 
 // Function for printing booleans

--- a/gpio_control/index.js
+++ b/gpio_control/index.js
@@ -198,7 +198,7 @@ GPIOControl.prototype.getUIConfig = function() {
 				self.setSelectElement(uiconf, s5, config.get(c5), self.unitsToString(config.get(c5))); // delay units
 				self.setSelectElement(uiconf, s6, config.get(c6), self.durationToString(config.get(c6))); // duration
 				self.setSelectElement(uiconf, s7, config.get(c7), self.unitsToString(config.get(c7))); // duration units
-				self.setSelectElement(uiconf, s8, config.get(c8)); // cancel delayed events
+				self.setSwitchElement(uiconf, s8, config.get(c8)); // cancel delayed events
 			});
 
 			defer.resolve(uiconf);

--- a/gpio_control/index.js
+++ b/gpio_control/index.js
@@ -395,6 +395,8 @@ GPIOControl.prototype.handleEvent = function(e) {
 
 // Cancel all delayed events
 GPIOControl.prototype.cancelAllDelayedEvents = function() {
+	var self = this;
+	
 	// Clear any previous delay timers
 	self.log('Cancelling all previous delayed events');
 	self.GPIOs.forEach(function(gpio) {


### PR DESCRIPTION
This can be useful if you are controlling an external device such as an amp and you don't want to short cycle it by simply skipping songs or pausing a song for a short time. In fact, this is what I am using it for currently, with this modification.

The "Amplifier Switch" plugin was filling this role for me for a short while, but it is causing system problems, so I removed it. Expanding this plugin has other uses besides just an amplifier switch I imagine.