### PR TITLE
Touch Display 3.3.6

### DIFF
--- a/touch_display/README.md
+++ b/touch_display/README.md
@@ -1,5 +1,7 @@
 # Touch Display plugin
 
+**NOTE: The plugin cannot be installed on systems that have a factory option to display Volumio's UI via HDMI video output.**
+
 The plugin enables the display of Volumio's UI on locally connected screens. If the screen offers touch control, apart from keyboard input the UI can be operated from the screen. The plugin focuses on the original Raspberry Pi Foundation 7" display (and compatible DSI displays), but can in principle also be used with displays connected via HDMI or GPIO. However, HDMI and GPIO displays usually require additional action by the user, depending on the type of display and any touch controller present, and **requiring advanced knowledge**.
 
 The following features are available on the plugin’s configuration page (other screens than the the original Raspberry Pi Foundation display may not have all of them available):

--- a/touch_display/UIConfig.json
+++ b/touch_display/UIConfig.json
@@ -10,7 +10,7 @@
                 "description": "TRANSLATE.TOUCH_DISPLAY.SCREENSAVER_DESC",
                 "icon": "fa-clock-o",
                 "hidden": "false",
-                "onSave": {"type":"controller", "endpoint":"${plugin_type}/touch_display", "method":"saveScreensaverConf"},
+                "onSave": {"type":"controller", "endpoint":"${plugin_type/plugin_name}", "method":"saveScreensaverConf"},
                 "saveButton": {
                               "label": "TRANSLATE.TOUCH_DISPLAY.APPLY",
                               "data": [
@@ -49,7 +49,7 @@
                 "description": "TRANSLATE.TOUCH_DISPLAY.BRIGHTNESS_DESC",
                 "icon": "fa-sun-o",
                 "hidden": "false",
-                "onSave": {"type":"controller", "endpoint":"${plugin_type}/touch_display", "method":"saveBrightnessConf"},
+                "onSave": {"type":"controller", "endpoint":"${plugin_type/plugin_name}", "method":"saveBrightnessConf"},
                 "saveButton": {
                               "label": "TRANSLATE.TOUCH_DISPLAY.APPLY",
                               "data": [
@@ -108,7 +108,7 @@
                              "element": "button",
                              "doc": "TRANSLATE.TOUCH_DISPLAY.CALIBRATION_DOC",
                              "label": "TRANSLATE.TOUCH_DISPLAY.CALIBRATION",
-                             "onClick": {"type":"controller", "endpoint":"${plugin_type}/touch_display", "method":"getAlsValue", "data":{"confData": "", "action": "minmax"}},
+                             "onClick": {"type":"controller", "endpoint":"${plugin_type/plugin_name}", "method":"getAlsValue", "data":{"confData": "", "action": "minmax"}},
                              "visibleIf": {"field": "autoMode", "value": true}
                              },
                              {
@@ -139,7 +139,7 @@
                              "element": "button",
                              "doc": "TRANSLATE.TOUCH_DISPLAY.GET_MID_ALS_DOC",
                              "label": "TRANSLATE.TOUCH_DISPLAY.GET_MID_ALS",
-                             "onClick": {"type":"controller", "endpoint":"${plugin_type}/touch_display", "method":"getAlsValue", "data":{"confData": "", "action": "mid"}},
+                             "onClick": {"type":"controller", "endpoint":"${plugin_type/plugin_name}", "method":"getAlsValue", "data":{"confData": "", "action": "mid"}},
                              "visibleIf": {"field": "autoMode", "value": true}
                              },
                              {
@@ -211,7 +211,7 @@
                 "description": "TRANSLATE.TOUCH_DISPLAY.ORIENTATION_DESC",
                 "icon": "fa-compass",
                 "hidden": "false",
-                "onSave": {"type":"controller", "endpoint":"${plugin_type}/touch_display", "method":"saveOrientationConf"},
+                "onSave": {"type":"controller", "endpoint":"${plugin_type/plugin_name}", "method":"saveOrientationConf"},
                 "saveButton": {
                               "label": "TRANSLATE.TOUCH_DISPLAY.APPLY",
                               "data": [
@@ -253,7 +253,7 @@
                 "description": "TRANSLATE.TOUCH_DISPLAY.GPUMEM_DESC",
                 "icon": "fa-microchip",
                 "hidden": "false",
-                "onSave": {"type":"controller", "endpoint":"${plugin_type}/touch_display", "method":"saveGpuMemConf"},
+                "onSave": {"type":"controller", "endpoint":"${plugin_type/plugin_name}", "method":"saveGpuMemConf"},
                 "saveButton": {
                               "label": "TRANSLATE.TOUCH_DISPLAY.APPLY",
                               "data": [
@@ -293,7 +293,7 @@
                 "description": "TRANSLATE.TOUCH_DISPLAY.POINTER_DESC",
                 "icon": "fa-mouse-pointer",
                 "hidden": "false",
-                "onSave": {"type":"controller", "endpoint":"${plugin_type}/touch_display", "method":"savePointerConf"},
+                "onSave": {"type":"controller", "endpoint":"${plugin_type/plugin_name}", "method":"savePointerConf"},
                 "saveButton": {
                               "label": "TRANSLATE.TOUCH_DISPLAY.APPLY",
                               "data": [
@@ -317,7 +317,7 @@
                 "description": "TRANSLATE.TOUCH_DISPLAY.SCALE_DESC",
                 "icon": "fa-expand",
                 "hidden": "false",
-                "onSave": {"type":"controller", "endpoint":"${plugin_type}/touch_display", "method":"saveScaleConf"},
+                "onSave": {"type":"controller", "endpoint":"${plugin_type/plugin_name}", "method":"saveScaleConf"},
                 "saveButton": {
                               "label": "TRANSLATE.TOUCH_DISPLAY.APPLY",
                               "data": [

--- a/touch_display/install.sh
+++ b/touch_display/install.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 
-PLUGIN_DIR="$(cd "$(dirname "$0")"; pwd -P)"
-
 exit_cleanup() {
-  if [ "$?" -ne 0 ]; then
+  ERR="$?"
+  if [ "$ERR" -ne 0 ]; then
     echo "Plugin failed to install!"
     echo "Cleaning up..."
     if [ -d "$PLUGIN_DIR" ]; then
-      . ."$PLUGIN_DIR"/uninstall.sh | grep -v "pluginuninstallend"
+      [ "$ERR" -eq 1 ] && . ."$PLUGIN_DIR"/uninstall.sh | grep -v "pluginuninstallend"
       echo "Removing plugin directory $PLUGIN_DIR"
       rm -rf "$PLUGIN_DIR"
     else
@@ -25,10 +24,17 @@ exit_cleanup() {
 }
 trap "exit_cleanup" EXIT
 
-echo "Completing \"UIConfig.json\""
-sed -i "s/\${plugin_type}/$(grep "\"plugin_type\":" "$PLUGIN_DIR"/package.json | cut -d"\"" -f4)/" "$PLUGIN_DIR"/UIConfig.json || { echo "Completing \"UIConfig.json\" failed"; exit 1; }
+PLUGIN_DIR="$(cd "$(dirname "$0")" && pwd -P)" || { echo "Determination of plugin folder's name failed"; exit 3; }
+PLUGIN_TYPE=$(grep "\"plugin_type\":" "$PLUGIN_DIR"/package.json | cut -d "\"" -f 4) || { echo "Determination of plugin type failed"; exit 3; }
+PLUGIN_NAME=$(grep "\"name\":" "$PLUGIN_DIR"/package.json | cut -d "\"" -f 4) || { echo "Determination of plugin name failed"; exit 3; }
 
-TMP_DIR="$(mktemp -d touch_display-XXXXXXXXXX)" || { echo "Creating temporary directory failed"; exit 1; }
+# do not install on systems equipped with kiosk mode ex works
+(grep -qi 'motivo' /etc/os-release || grep -Pozq '"id": "section_hdmi_settings",\s*"element": "section",\s*"hidden": false' /volumio/app/plugins/system_controller/system/UIConfig.json) && { echo "The plugin is not suitable for this device"; exit 3; }
+
+sed -i "s/\${plugin_type\/plugin_name}/$PLUGIN_TYPE\/$PLUGIN_NAME/" "$PLUGIN_DIR"/UIConfig.json || { echo "Completing \"UIConfig.json\" failed"; exit 3; }
+
+TMP_DIR="$(mktemp -dt "$PLUGIN_NAME"-XXXXXXXXXX)" || { echo "Creating temporary directory failed"; exit 3; }
+
 export DEBIAN_FRONTEND=noninteractive
 
 if grep -q Raspberry /proc/cpuinfo; then # on Raspberry Pi hardware
@@ -43,9 +49,9 @@ if grep -q Raspberry /proc/cpuinfo; then # on Raspberry Pi hardware
   echo "Putting on hold packages for kernel, bootloader and pi lib"
   apt-mark hold libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel || { echo "Putting on hold packages for kernel, bootloader and pi lib failed"; exit 1; }
 
-  echo "Installing Chromium dependencies"
-  apt-get update
-  apt-get -y install || { echo "Installation of Chromium dependencies failed"; exit 1; }
+  echo "Re-synchronizing package index files from their sources"
+  apt-get update || { echo "Running apt-get update failed"; exit 1; }
+  apt-get -y install || { echo "Running apt-get -y install failed"; exit 1; }
 
   echo "Installing graphical environment"
   apt-get -y install xinit || { echo "Installation of xinit failed"; exit 1; }
@@ -68,9 +74,9 @@ Section \"InputClass\"
         MatchDriver \"libinput|evdev\"
 EndSection" > /etc/X11/xorg.conf.d/95-touch_display-plugin.conf || { echo "Creating Xorg configuration file failed"; exit 1; }
 else # on other hardware
-  echo "Installing Chromium dependencies"
-  apt-get update
-  apt-get -y install || { echo "Installation of Chromium dependencies failed"; exit 1; }
+  echo "Re-synchronizing package index files from their sources"
+  apt-get update || { echo "Running apt-get update failed"; exit 1; }
+  apt-get -y install || { echo "Running apt-get -y install failed"; exit 1; }
 
   echo "Installing graphical environment"
   apt-get -y install xinit || { echo "Installation of xinit failed"; exit 1; }
@@ -79,7 +85,7 @@ else # on other hardware
 
   echo "Installing Chromium"
   apt-get -y install chromium || { echo "Installation of Chromium failed"; exit 1; }
-  ln -s /usr/bin/chromium /usr/bin/chromium-browser || { echo "Linking /usr/bin/chromium to /usr/bin/chromium-browser failed"; exit 1; }
+  ln -fs /usr/bin/chromium /usr/bin/chromium-browser || { echo "Linking /usr/bin/chromium to /usr/bin/chromium-browser failed"; exit 1; }
 fi
 
 echo "Installing japanese, korean, chinese and taiwanese fonts"

--- a/touch_display/package.json
+++ b/touch_display/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "touch_display",
 	"version": "3.3.6",
-	"description": "The plugin enables displaying and operating Volumio's UI on a locally connected screen.<br><br><b style=\"color:red\">NOTE: The plugin cannot be installed on systems that have a factory option to display the UI via HDMI video output.</b>",
+	"description": "The plugin enables displaying and operating Volumio's UI on a locally connected screen. NOTE: The plugin cannot be installed on systems that have a factory option to display the UI via HDMI video output.",
 	"main": "index.js",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"
@@ -19,7 +19,7 @@
 		"os": [
 			"buster"
 		],
-		"details": "The plugin enables the display of Volumio's UI on locally connected screens. If the screen offers touch control, apart from keyboard input the UI can be operated from the screen.<br><br>The plugin focuses on the Raspberry Pi Foundation's 7\" display (and compatible DSI displays), but can in principle also be used with displays connected via HDMI or GPIO. However, HDMI and GPIO displays usually require additional action by the user, depending on the type of display and any touch controller present, and <b>requiring advanced knowledge</b>.<br><br><b style=\"color:red\">NOTE: The plugin cannot be installed on systems that have a factory option to display the UI via HDMI video output.</b>",
+		"details": "The plugin enables the display of Volumio's UI on locally connected screens. If the screen offers touch control, apart from keyboard input the UI can be operated from the screen.<br><br>The plugin focuses on the Raspberry Pi Foundation's 7\" display (and compatible DSI displays), but can in principle also be used with displays connected via HDMI or GPIO. However, HDMI and GPIO displays usually require additional action by the user, depending on the type of display and any touch controller present, and <b>requiring advanced knowledge</b>.<br><br><b style=\"color:red;\">NOTE: The plugin cannot be installed on systems that have a factory option to display the UI via HDMI video output.</b>",
 		"changelog": "Prevent installation on devices that have kiosk mode built in; fixed error on non-Pi platforms on plugin update"
 	},
 	"engines": {

--- a/touch_display/package.json
+++ b/touch_display/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "touch_display",
-	"version": "3.3.5",
-	"description": "The plugin enables displaying and operating Volumio's UI on a original Raspberry 7\" touchscreen.",
+	"version": "3.3.6",
+	"description": "The plugin enables displaying and operating Volumio's UI on a locally connected screen.<br><br><b style=\"color:red\">NOTE: The plugin cannot be installed on systems that have a factory option to display the UI via HDMI video output.</b>",
 	"main": "index.js",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"
@@ -19,8 +19,8 @@
 		"os": [
 			"buster"
 		],
-		"details": "The plugin enables the display of Volumio's UI on locally connected screens. If the screen offers touch control, apart from keyboard input the UI can be operated from the screen.<br><br>The plugin focuses on the Raspberry Pi Foundation's 7\" display (and compatible DSI displays), but can in principle also be used with displays connected via HDMI or GPIO. However, HDMI and GPIO displays usually require additional action by the user, depending on the type of display and any touch controller present, and <b>requiring advanced knowledge</b>.",
-		"changelog": "Removed hard coding of plugin type dependent endpoint and category specifications"
+		"details": "The plugin enables the display of Volumio's UI on locally connected screens. If the screen offers touch control, apart from keyboard input the UI can be operated from the screen.<br><br>The plugin focuses on the Raspberry Pi Foundation's 7\" display (and compatible DSI displays), but can in principle also be used with displays connected via HDMI or GPIO. However, HDMI and GPIO displays usually require additional action by the user, depending on the type of display and any touch controller present, and <b>requiring advanced knowledge</b>.<br><br><b style=\"color:red\">NOTE: The plugin cannot be installed on systems that have a factory option to display the UI via HDMI video output.</b>",
+		"changelog": "Prevent installation on devices that have kiosk mode built in; fixed error on non-Pi platforms on plugin update"
 	},
 	"engines": {
 		"node": ">=8",

--- a/touch_display/uninstall.sh
+++ b/touch_display/uninstall.sh
@@ -16,6 +16,7 @@ else # on other hardware
   apt-get -y purge --auto-remove chromium
   apt-get -y purge --auto-remove openbox
   apt-get -y purge --auto-remove xinit
+  rm /usr/bin/chromium-browser
 fi
 
 echo "Deleting /opt/volumiokiosk.sh"


### PR DESCRIPTION
Prevent installation on devices that have kiosk mode built in, after repeated reports on the forum (e.g. [here](https://community.volumio.org/t/error-when-trying-to-install-touch-display-plugin/58652/35)) about attempts to install the plugin on such devices; fixed error on plugin update affecting non-Pi platforms (disovered [here](https://community.volumio.org/t/odroid-n2-does-not-recognize-1440x900-screen-with-3-3-5-touchscreen-plugin/58514/20)).

Reworked description and details texts in package.json and added a note regarding devices with a factory option to display Volumio's UI via HDMI video output to package.json as well as to README.md.