### PR TITLE
RemotePi 3.2.0

### DIFF
--- a/remotepi/README.md
+++ b/remotepi/README.md
@@ -9,6 +9,6 @@ This allows the RemotePi board to cut power from the RasPi after the shutdown pr
 Furthermore the plugin detects the signal that is sent by the RemotePi board in case its hardware knob has been pressed or an IR power off signal from a remote control has been received. The plugin then initiates the shutdown of Volumio and sends a signal back to the RemotePi. This allows the board to detect when Volumio’s shutdown process has finished and cut the power afterwards.
 
 ## Set up IR receiver for LIRC
-The plugin configures Volumio to load the necessary overlay for the IR receiver of the RemotePi board. By default the plugin uses GPIO18 for the IR receiver. But as the hardware of RemotePi boards can be modified to use GPIO17 instead the plugin allows to set up the configuration accordingly.
+The plugin configures Volumio to load the necessary overlay for the IR receiver of the RemotePi board. This behaviour can be switched off. By default the plugin uses GPIO18 for the IR receiver. But as the hardware of RemotePi boards can be modified to use GPIO17 instead the plugin allows to set up the configuration accordingly.
 
 **Note: The plugin will not install and setup LIRC!** This can be achieved by installing the IR Remote Controller plugin.

--- a/remotepi/UIConfig.json
+++ b/remotepi/UIConfig.json
@@ -1,30 +1,40 @@
 {
-  "page": {
-          "label": "TRANSLATE.REMOTEPI.PLUGIN_CONFIGURATION"
-          },
-  "sections": [
-                {
-                "id": "remotepi_conf",
-                "element": "section",
-                "label": "TRANSLATE.REMOTEPI.REMOTEPI_CONF",
-                "description": "TRANSLATE.REMOTEPI.REMOTEPI_DESC",
-                "icon": "fa-cogs",
-                "onSave": {"type":"controller", "endpoint":"${plugin_type}/remotepi", "method":"saveConf"},
-                "saveButton": {
-                              "label": "TRANSLATE.REMOTEPI.SAVE",
-                              "data": [
-                                      "gpio17"
-                                      ]
-                              },
-                "content": [
-                             {
-                             "id": "gpio17",
-                             "element": "switch",
-                             "doc": "TRANSLATE.REMOTEPI.GPIO17_DOC",
-                             "label": "TRANSLATE.REMOTEPI.GPIO17",
-                             "value": false
-                             }
-                           ]
-                }
-              ]
-}
+        "page": {
+                "label": "TRANSLATE.REMOTEPI.PLUGIN_CONFIGURATION"
+                },
+        "sections": [
+                      {
+                      "id": "remotepi_conf",
+                      "element": "section",
+                      "label": "TRANSLATE.REMOTEPI.REMOTEPI_CONF",
+                      "description": "TRANSLATE.REMOTEPI.REMOTEPI_DESC",
+                      "icon": "fa-cogs",
+                      "onSave": {"type":"controller", "endpoint":"${plugin_type/plugin_name}", "method":"saveConf"},
+                      "saveButton": {
+                                    "label": "TRANSLATE.REMOTEPI.SAVE",
+                                    "data": [
+                                            "gpio_configuration",
+                                            "gpio17"
+                                            ]
+                                    },
+                      "content": [
+                                   {
+                                   "id": "gpio_configuration",
+                                   "element": "switch",
+                                   "doc": "TRANSLATE.REMOTEPI.GPIO_CONFIGURATION_DOC",
+                                   "label": "TRANSLATE.REMOTEPI.GPIO_CONFIGURATION",
+                                   "value": true
+                                   },
+                                   {
+                                   "id": "gpio17",
+                                   "element": "switch",
+                                   "doc": "TRANSLATE.REMOTEPI.GPIO17_DOC",
+                                   "label": "TRANSLATE.REMOTEPI.GPIO17",
+                                   "visibleIf": {"field": "gpio_configuration", "value": true},
+                                   "value": false
+                                   }
+                                 ]
+                      }
+                    ]
+      }
+      

--- a/remotepi/config.json
+++ b/remotepi/config.json
@@ -1,4 +1,8 @@
 {
+  "gpio_configuration": {
+  "type": "boolean",
+	"value": true
+  },
   "enable_gpio17": {
 	"type": "boolean",
 	"value": false

--- a/remotepi/i18n/strings_de.json
+++ b/remotepi/i18n/strings_de.json
@@ -1,6 +1,9 @@
 {
   "REMOTEPI":{
     "PLUGIN_NAME":"RemotePi",
+    "ERR_RECONF14":"Rekonfiguration von GPIO 14 fehlgeschlagen: ",
+    "ERR_CONF14":"Konfiguration von GPIO 14 fehlgeschlagen: ",
+    "ERR_CONF15":"Konfiguration von GPIO 15 fehlgeschlagen: ",
     "ERR_WRITE":"Fehler beim Schreiben von ",
     "ERR_READ":"Fehler beim Lesen von ",
     "REBOOT_MSG":"Ein Neustart ist erforderlich, damit die Änderung wirksam wird.",
@@ -8,6 +11,8 @@
     "PLUGIN_CONFIGURATION":"RemotePi Konfiguration",
     "REMOTEPI_CONF":"IR-Empfänger-Einstellungen",
     "REMOTEPI_DESC":"Um den IR-Empänger des RemotePi über die Ein-/Ausschaltfunktion hinaus nutzen zu können, muss zusätzlich LIRC eingerichtet werden. Das Plugin \"IR Remote Controller\" leistet dies und enthält auch Konfigurationen für verschiedene Fernbedienungen. Da das Ein- und Ausschalten vom RemotePi-Board selbst gesteuert wird, muss aus den vom \"IR Remote Controller\"-Plugin zur Verfügung gestellten lircd.conf-Dateien ein etwaig vorhandener Schlüssel für die Taste, die zum Ausschalten genutzt werden soll, oder aus den lircrc-Dateien ein auf diese Taste bezogener Abschnitt entfernt werden.",
+    "GPIO_CONFIGURATION":"GPIO Konfiguration",
+    "GPIO_CONFIGURATION_DOC":"Wenn der Schalter aktiviert ist, wird beim Systemstart automatisch das für den IR-Empänger notwendige IR-Overlay geladen.",
     "GPIO17":"GPIO-Port 17 für den IR-Empfänger nutzen",
     "GPIO17_DOC":"Diese Option ist zu aktivieren, falls die RemotePi-Platine so modifiziert wurde, dass der IR-Empfäger den GPIO-Port 17 statt GPIO-Port 18 nutzt.",
     "SAVE":"Speichern"

--- a/remotepi/i18n/strings_en.json
+++ b/remotepi/i18n/strings_en.json
@@ -1,6 +1,9 @@
 {
   "REMOTEPI":{
     "PLUGIN_NAME":"RemotePi",
+    "ERR_RECONF14":"Reconfiguring GPIO 14 failed: ",
+    "ERR_CONF14":"Configuring GPIO 14 failed: ",
+    "ERR_CONF15":"Configuring GPIO 15 failed: ",
     "ERR_WRITE":"Error writing ",
     "ERR_READ":"Error reading ",
     "REBOOT_MSG":"A reboot is required for the change to take effect.",
@@ -8,6 +11,8 @@
     "PLUGIN_CONFIGURATION":"RemotePi Configuration",
     "REMOTEPI_CONF":"IR receiver settings",
     "REMOTEPI_DESC":"In order to use the IR receiver of the RemotePi for more than powering on/off LIRC has also to be set up. The plugin \"IR Remote Controller\" does this and also offers configurations for various remote controls. As powering on and off by IR remote control is handled by the RemotePi board directly a possibly existing key for the button used for powering down has to be removed from the lircd.conf files or a section referring to this button has to be removed from the lircrc files which are provided by the \"IR Remote Controller\" plugin.",
+    "GPIO_CONFIGURATION":"GPIO Configuration",
+    "GPIO_CONFIGURATION_DOC":"If the switch is enabled, the IR overlay required for the IR receiver is automatically loaded at system startup.",
     "GPIO17":"Use GPIO port 17 for IR receiver",
     "GPIO17_DOC":"This option needs to be enabled if the RemotePi board has been modified to use GPIO port 17 for the IR receiver instead of GPIO port 18.",
     "SAVE":"Save"

--- a/remotepi/i18n/strings_fr.json
+++ b/remotepi/i18n/strings_fr.json
@@ -1,6 +1,9 @@
 {
   "REMOTEPI":{
     "PLUGIN_NAME":"RemotePi",
+    "ERR_RECONF14":"La reconfiguration du GPIO 14 a échoué: ",
+    "ERR_CONF14":"La configuration de GPIO 14 a échoué: ",
+    "ERR_CONF15":"La configuration de GPIO 15 a échoué: ",
     "ERR_WRITE":"Erreur d'écriture ",
     "ERR_READ":"Erreur de lecture ",
     "REBOOT_MSG":"Un redémarrage est nécéssaire pour prendre en charge les nouveaux réglages",
@@ -8,6 +11,8 @@
     "PLUGIN_CONFIGURATION":"Configuration de RemotePi",
     "REMOTEPI_CONF":"Réglages du récepteur IR",
     "REMOTEPI_DESC":"Pour utiliser le récepteur IR de la RemotePi au-delà de la fonction on/off, LIRC doit être configuré en plus. Le plugin \"IR Remote Controller\" fait cela et contient également des configurations pour différentes télécommandes. Puisque la mise sous/hors tension est contrôlée par la carte RemotePi elle-même, vous devez supprimer des fichiers lircd.conf fournis par le plugin \"IR Remote Controller\" toute clé existante pour le bouton à utiliser pour la mise hors tension, ou des fichiers lircrc une section relative à ce bouton.",
+    "GPIO_CONFIGURATION":"Configuration GPIO",
+    "GPIO_CONFIGURATION_DOC":"Si le commutateur est activé, la superposition IR requise pour le récepteur IR est automatiquement chargée au démarrage du système.",
     "GPIO17":"Utilisation du port GPIO 17 pour le récepteur IR",
     "GPIO17_DOC":"Cette option doit être activée si la carte RemotePi a été modifiée pour que le récepteur IR utilise le port GPIO 17 au lieu du port GPIO 18.",
     "SAVE":"Appliquer"

--- a/remotepi/index.js
+++ b/remotepi/index.js
@@ -5,7 +5,6 @@ const fs = require('fs-extra');
 const path = require('path');
 const os = require('os');
 const { Gpio } = require('onoff');
-const id = 'remotepi: ';
 let hwShutdown = false;
 let shutdownCtrl, initShutdown;
 
@@ -18,6 +17,7 @@ function remotepi (context) {
   self.commandRouter = self.context.coreCommand;
   self.logger = self.context.logger;
   self.configManager = self.context.configManager;
+  self.pluginName = self.commandRouter.pluginManager.getPackageJson(__dirname).name;
 }
 
 remotepi.prototype.onVolumioStart = function () {
@@ -31,27 +31,37 @@ remotepi.prototype.onVolumioStart = function () {
 
 remotepi.prototype.onVolumioShutdown = function () {
   const self = this;
+  /* global Atomics, SharedArrayBuffer */
+  const msleep = n => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, n);
 
-  if (!hwShutdown) {
-    self.logger.info(id + 'Shutdown initiated by UI');
-    // Execute shutdown signal sequence on GPIO15
-    initShutdown.write(1);
-    self.msleep(125);
-    initShutdown.write(0);
-    self.msleep(200);
-    initShutdown.write(1);
-    self.msleep(400);
-    initShutdown.write(0);
-  } else {
-    self.logger.info(id + 'Shutdown initiated by hardware knob or IR remote control');
+  try {
+    if (!hwShutdown) {
+      self.logger.info(self.pluginName + ': Shutdown initiated by UI');
+      // Execute shutdown signal sequence on GPIO15
+      initShutdown.writeSync(1);
+      msleep(125);
+      initShutdown.writeSync(0);
+      msleep(200);
+      initShutdown.writeSync(1);
+      msleep(400);
+      initShutdown.writeSync(0);
+    } else {
+      self.logger.info(self.pluginName + ': Shutdown initiated by hardware knob or IR remote control');
+    }
+    try {
+      // Reconfigure GPIO14 as output with initial "high" level allowing the RemotePi
+      // to recognize when the shutdown process on the RasPi has been finished
+      shutdownCtrl.unwatchAll();
+      shutdownCtrl.setEdge('none');
+      shutdownCtrl.setDirection('high');
+      msleep(4000);
+    } catch (e) {
+      self.logger.error(self.pluginName + ': Reconfiguring GPIO 14 for shutdown failed: ' + e);
+      self.commandRouter.pushToastMessage('error', self.commandRouter.getI18nString('REMOTEPI.PLUGIN_NAME'), self.commandRouter.getI18nString('REMOTEPI.ERR_RECONF14') + ': ' + e);
+    }
+  } catch (e) {
+    self.logger.error(self.pluginName + ': Wrting the shutdown signal sequence to GPIO 15 failed: ' + e);
   }
-  // Reconfigure GPIO14 as output. Then set it to "high" to allow the RemotePi
-  // to recognize when the shutdown process on the RasPi has been finished
-  shutdownCtrl.unwatchAll();
-  shutdownCtrl.unexport();
-  shutdownCtrl = new Gpio(14, 'out');
-  shutdownCtrl.write(1);
-  self.msleep(4000);
   return libQ.resolve();
 };
 
@@ -59,9 +69,42 @@ remotepi.prototype.onStart = function () {
   const self = this;
 
   self.commandRouter.loadI18nStrings();
-  self.dtctHwShutdown();
-  initShutdown = new Gpio(15, 'out');
-  self.modBootConfig(self.config.get('enable_gpio17'));
+  try {
+    const defaultConfig = fs.readJsonSync(path.join(__dirname, 'config.json'));
+    for (const configItem in defaultConfig) {
+      if (!self.config.has(configItem)) {
+        self.config.set(configItem, defaultConfig[configItem].value);
+      }
+    }
+  } catch (e) {
+    self.logger.error(self.pluginName + ': Failed to read default configuration from ' + path.join(__dirname, 'config.json: ') + e);
+  }
+  try {
+    // As the RemotePi signals a shutdown event (hardware knob or IR receiver) to the RasPi by
+    // setting the level on the pin of GPIO14 to "high" configure GPIO14 as input and watch it
+    shutdownCtrl = new Gpio(14, 'in', 'rising');
+    shutdownCtrl.watch((err, value) => {
+      if (err) {
+        self.logger.error(self.pluginName + ': Error watching GPIO 14: ' + err);
+      } else if (value === 1) {
+        hwShutdown = true;
+        return self.commandRouter.shutdown();
+      }
+    });
+  } catch (e) {
+    self.logger.error(self.pluginName + ': Configuring GPIO 14 failed: ' + e);
+    self.commandRouter.pushToastMessage('error', self.commandRouter.getI18nString('REMOTEPI.PLUGIN_NAME'), self.commandRouter.getI18nString('REMOTEPI.ERR_CONF14') + ': ' + e);
+    return libQ.reject();
+  }
+  try {
+    initShutdown = new Gpio(15, 'out');
+  } catch (e) {
+    shutdownCtrl.unexport();
+    self.logger.error(self.pluginName + ': Configuring GPIO 15 failed: ' + e);
+    self.commandRouter.pushToastMessage('error', self.commandRouter.getI18nString('REMOTEPI.PLUGIN_NAME'), self.commandRouter.getI18nString('REMOTEPI.ERR_CONF15') + ': ' + e);
+    return libQ.reject();
+  }
+  self.modBootConfig(self.config.get('gpio_configuration') ? self.config.get('enable_gpio17') : '');
   return libQ.resolve();
 };
 
@@ -69,9 +112,12 @@ remotepi.prototype.onStop = function () {
   const self = this;
 
   self.modBootConfig('');
-  shutdownCtrl.unwatchAll();
-  shutdownCtrl.unexport();
-  initShutdown.unexport();
+  try {
+    shutdownCtrl.unexport();
+    initShutdown.unexport();
+  } catch (e) {
+    self.logger.error(self.pluginName + ': Freeing GPIO resources failed: ' + e);
+  }
   return libQ.resolve();
 };
 
@@ -85,12 +131,13 @@ remotepi.prototype.getUIConfig = function () {
   self.commandRouter.i18nJson(path.join(__dirname, 'i18n', 'strings_' + langCode + '.json'),
     path.join(__dirname, 'i18n', 'strings_en.json'),
     path.join(__dirname, 'UIConfig.json'))
-    .then(function (uiconf) {
-      uiconf.sections[0].content[0].value = self.config.get('enable_gpio17');
+    .then(uiconf => {
+      uiconf.sections[0].content[0].value = self.config.get('gpio_configuration');
+      uiconf.sections[0].content[1].value = self.config.get('enable_gpio17');
       defer.resolve(uiconf);
     })
-    .fail(function (e) {
-      self.logger.error(id + 'Could not fetch UI configuration: ' + e);
+    .fail(e => {
+      self.logger.error(self.pluginName + ': Could not fetch UI configuration: ' + e);
       defer.reject(new Error());
     });
   return defer.promise;
@@ -105,14 +152,14 @@ remotepi.prototype.getI18nFile = function (langCode) {
   const langFile = 'strings_' + langCode + '.json';
 
   try {
-    const i18nFiles = fs.readdirSync(path.join(__dirname, 'i18n'));
     // check for i18n file fitting the system language
-    if (i18nFiles.some(function (i18nFile) { return i18nFile === langFile; })) {
+    if (fs.readdirSync(path.join(__dirname, 'i18n'), { withFileTypes: true })
+      .some(item => item.isFile() && item.name === langFile)) {
       return path.join(__dirname, 'i18n', langFile);
     }
     throw new Error('i18n file complementing the system language not found.');
   } catch (e) {
-    self.logger.error(id + 'Fetching language file: ' + e);
+    self.logger.error(self.pluginName + ': Fetching language file: ' + e);
     // return default i18n file
     return path.join(__dirname, 'i18n', 'strings_en.json');
   }
@@ -140,9 +187,10 @@ remotepi.prototype.saveConf = function (data) {
     ]
   };
 
-  if (self.config.get('enable_gpio17') !== data.gpio17) {
+  if (self.config.get('gpio_configuration') !== data.gpio_configuration || self.config.get('enable_gpio17') !== data.gpio17) {
+    self.config.set('gpio_configuration', data.gpio_configuration);
     self.config.set('enable_gpio17', data.gpio17);
-    self.modBootConfig(data.gpio17);
+    self.modBootConfig(data.gpio_configuration ? data.gpio17 : '');
     self.commandRouter.broadcastMessage('openModal', responseData);
   } else {
     self.commandRouter.pushToastMessage('info', self.commandRouter.getI18nString('REMOTEPI.PLUGIN_NAME'), self.commandRouter.getI18nString('REMOTEPI.NO_CHANGES'));
@@ -150,28 +198,6 @@ remotepi.prototype.saveConf = function (data) {
 };
 
 // Plugin Methods ------------------------------------------------------------------------------------
-
-remotepi.prototype.msleep = function (n) {
-  /* global Atomics, SharedArrayBuffer */
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, n);
-};
-
-remotepi.prototype.dtctHwShutdown = function () {
-  const self = this;
-
-  // As the RemotePi signals a shutdown event (hardware knob or IR receiver) to the RasPi by
-  // setting the level on the pin of GPIO14 to "high" configure GPIO14 as input and watch it
-  shutdownCtrl = new Gpio(14, 'in', 'rising');
-  shutdownCtrl.watch(function (err, value) {
-    if (err) {
-      throw err;
-    }
-    if (value === 1) {
-      hwShutdown = true;
-      return self.commandRouter.shutdown();
-    }
-  });
-};
 
 remotepi.prototype.modBootConfig = function (gpio17) {
   const self = this;
@@ -194,16 +220,16 @@ remotepi.prototype.modBootConfig = function (gpio17) {
           try {
             fs.writeFileSync('/boot/config.txt', newConfigTxt, 'utf8');
           } catch (e) {
-            self.logger.error(id + 'Error writing ' + configFile + ': ' + e);
+            self.logger.error(self.pluginName + ': Error writing ' + configFile + ': ' + e);
             self.commandRouter.pushToastMessage('error', self.commandRouter.getI18nString('REMOTEPI.PLUGIN_NAME'), self.commandRouter.getI18nString('REMOTEPI.ERR_WRITE') + configFile + ': ' + e);
           }
         }
       } catch (e) {
-        self.logger.error(id + 'Error reading ' + configFile + ': ' + e);
+        self.logger.error(self.pluginName + ': Error reading ' + configFile + ': ' + e);
         self.commandRouter.pushToastMessage('error', self.commandRouter.getI18nString('REMOTEPI.PLUGIN_NAME'), self.commandRouter.getI18nString('REMOTEPI.ERR_READ') + configFile + ': ' + e);
       }
     } else {
-      self.logger.info(id + 'Using /boot/config.txt instead of /boot/userconfig.txt. Reason: /boot/userconfig.txt is not a file.');
+      self.logger.info(self.pluginName + ': Using /boot/config.txt instead of /boot/userconfig.txt. Reason: /boot/userconfig.txt is not a file.');
       throw new Error();
     }
   } catch (e) {
@@ -224,12 +250,12 @@ remotepi.prototype.modBootConfig = function (gpio17) {
         try {
           fs.writeFileSync(configFile, newConfigTxt, 'utf8');
         } catch (e) {
-          self.logger.error(id + 'Error writing ' + configFile + ': ' + e);
+          self.logger.error(self.pluginName + ': Error writing ' + configFile + ': ' + e);
           self.commandRouter.pushToastMessage('error', self.commandRouter.getI18nString('REMOTEPI.PLUGIN_NAME'), self.commandRouter.getI18nString('REMOTEPI.ERR_WRITE') + configFile + ': ' + e);
         }
       }
     } catch (e) {
-      self.logger.error(id + 'Error reading ' + configFile + ': ' + e);
+      self.logger.error(self.pluginName + ': Error reading ' + configFile + ': ' + e);
       self.commandRouter.pushToastMessage('error', self.commandRouter.getI18nString('REMOTEPI.PLUGIN_NAME'), self.commandRouter.getI18nString('REMOTEPI.ERR_READ') + configFile + ': ' + e);
     }
   }

--- a/remotepi/install.sh
+++ b/remotepi/install.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 
-PLUGIN_DIR="$(cd "$(dirname "$0")"; pwd -P)"
-
 exit_cleanup() {
-  if [ "$?" -ne 0 ]; then
+  ERR="$?"
+  if [ "$ERR" -ne 0 ]; then
     echo "Plugin failed to install!"
     echo "Cleaning up..."
     if [ -d "$PLUGIN_DIR" ]; then
-      . ."$PLUGIN_DIR"/uninstall.sh | grep -v "pluginuninstallend"
+      [ "$ERR" -eq 1 ] && . ."$PLUGIN_DIR"/uninstall.sh | grep -v "pluginuninstallend"
       echo "Removing plugin directory $PLUGIN_DIR"
       rm -rf "$PLUGIN_DIR"
     else
@@ -23,13 +22,15 @@ exit_cleanup() {
 }
 trap "exit_cleanup" EXIT
 
-echo "Completing \"UIConfig.json\""
-sed -i "s/\${plugin_type}/$(grep "\"plugin_type\":" "$PLUGIN_DIR"/package.json | cut -d"\"" -f4)/" "$PLUGIN_DIR"/UIConfig.json || { echo "Completing \"UIConfig.json\" failed"; exit 1; }
+PLUGIN_DIR="$(cd "$(dirname "$0")" && pwd -P)" || { echo "Determination of plugin folder's name failed"; exit 3; }
+PLUGIN_TYPE=$(grep "\"plugin_type\":" "$PLUGIN_DIR"/package.json | cut -d "\"" -f 4) || { echo "Determination of plugin type failed"; exit 3; }
+PLUGIN_NAME=$(grep "\"name\":" "$PLUGIN_DIR"/package.json | cut -d "\"" -f 4) || { echo "Determination of plugin name failed"; exit 3; }
+
+sed -i "s/\${plugin_type\/plugin_name}/$PLUGIN_TYPE\/$PLUGIN_NAME/" "$PLUGIN_DIR"/UIConfig.json || { echo "Completing \"UIConfig.json\" failed"; exit 3; }
 
 echo "Installing build-essential"
-apt-get update
-apt-get -y install build-essential || { echo "Installing build-essential failed"; exit 1; }
+apt-get update || { echo "Running apt-get update failed"; exit 3; }
+apt-get -y install build-essential || { echo "Installing build-essential failed"; exit 3; }
 
 echo "Installing module \"onoff\""
-npm install --prefix "$PLUGIN_DIR" onoff@^6.0.0 || { echo "Installing module \"onoff\" failed"; exit 1; }
-
+npm install --prefix "$PLUGIN_DIR" onoff@^6.0.0 || { echo "Installing module \"onoff\" failed"; exit 3; }

--- a/remotepi/package.json
+++ b/remotepi/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "remotepi",
-	"version": "3.1.11",
+	"version": "3.2.0",
 	"description": "The plugin enables support for RemotePi boards.",
 	"main": "index.js",
 	"scripts": {
@@ -20,7 +20,7 @@
 			"buster"
 		],
 		"details": "The plugin enables support for RemotePi boards for Raspberry Pi 4, Pi 3 B+, Pi 3, Pi 2, B+ and B.<br><br>With the plugin the RemotePi board will manage cutting the power after Volumio has been shut down via the GUI or the RemotePi board's hardware knob has been pressed or a infrared power off signal (learned-in to the RemotePi board) has been received.",
-		"changelog": "Removed hard coding of plugin type dependent endpoint specifications"
+		"changelog": "Added switch to en-/disable GPIO configuration for LIRC"
 	},
 	"engines": {
 		"node": ">=8",


### PR DESCRIPTION
Added an option to en-/disable the automatic GPIO configuration by the plugin. With this option set to "enabled" (default) the plugin behaves like before and configures GPIO 18 or 17 (selectable) for the RemotePi boards' IR receiver. by modifying "/boot/userconfig.txt" so the required gpio-ir overlay is loaded on boot. Setting the new option to "disabled" now allows to prevent this. This can be useful e.g. if someone wants/has to use an IR receiver which is connected to another GPIO port and that can then be configured using the configuration options of the IR Controller plugin.

Besides that the PR contains some little code rework/linting.