### PR TITLE
LMS v1.2.6: installation on x86 and some minor fixes

### DIFF
--- a/lms/UIConfig.json
+++ b/lms/UIConfig.json
@@ -7,7 +7,7 @@
 			"element": "section",
 			"label": "TRANSLATE.LMS.NAVIGATE_TO_SERVER",
 			"description": "TRANSLATE.LMS.D_NAVIGATE_TO_SERVER",
-			"icon": "fa-windows-maximize",
+			"icon": "fa-window-maximize",
 			"content": [
 			{
 				"id": "open_webconfig",

--- a/lms/index.js
+++ b/lms/index.js
@@ -41,7 +41,8 @@ ControllerLMS.prototype.onStop = function() {
 	.fail(function(e)
 	{
 		self.commandRouter.pushToastMessage('error', "Stopping failed", "Could not stop the LMS plugin in a fashionable manner, error: " + e);
-		defer.reject(new error());
+		// Do not reject, in case user is uninstalling a possibly broken installation - rejecting will abort the process.
+		defer.resolve();
 	});
 
 	return defer.promise;

--- a/lms/index.js
+++ b/lms/index.js
@@ -117,7 +117,7 @@ ControllerLMS.prototype.getUIConfig = function() {
     .then(function(uiconf)
     {
 		self.logger.info("[LMS] Loading configuration...");
-		let consoleUrl = `http://${self.selfIP['eth0']}:9000`;
+		let consoleUrl = `http://${self.selfIP['eth0'] || self.selfIP['wlan0']}:9000`;
 		self.logger.info(`[LMS] Console URL: ${consoleUrl}`);
 		uiconf.sections[0].content[0].onClick.url = consoleUrl;
 		defer.resolve(uiconf);

--- a/lms/install.sh
+++ b/lms/install.sh
@@ -31,13 +31,13 @@ if [ ! -f $INSTALLING ]; then
 			FILE="$(cat $LATEST_LOCATION | grep debarm | awk -F 'url="|" version' '$0=$2')"
 			wget -O /home/volumio/logitechmediaserver/logitechmediaserver_arm.deb $FILE
 		elif [ $arch = "i686" ] || [ $arch = "x86_64" ]; then
-			#Not certain if correct cannot test
-			FILE= cat $LATEST_LOCATION | grep debarm | awk -F 'url="|" version' '$0=$2'
-			wget -O /home/volumio/logitechmediaserver/logitechmediaserver.deb $FILE
-		elif [ $arch = "x86_64" ]; then
-			#Not certain if correct cannot test
-			FILE= cat $LATEST_LOCATION | grep debamd64 | awk -F 'url="|" version' '$0=$2'
-			wget -O /home/volumio/logitechmediaserver/logitechmediaserver.deb $FILE
+			FILE="$(cat $LATEST_LOCATION | grep debamd64 | awk -F 'url="|" version' '$0=$2')"
+			wget -O /home/volumio/logitechmediaserver/logitechmediaserver_amd64.deb $FILE
+		else
+			echo "Incompatible architecture. Installation cannot continue."
+			rm -rf /home/volumio/logitechmediaserver
+			rm $INSTALLING
+			exit 1
 		fi
 
 		# Move the binary to the expected directory

--- a/lms/package.json
+++ b/lms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lms",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"description": "Installs the Logitech Media Server application and web client",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
This PR enables installation of the LMS plugin (by Saiyato and @LarsGrootkarzijn ) on x86 machines, and also includes some minor fixes.

The idea is to retire the LMS Docker Edition plugin which existed to work around incompatible Perl modules with the non-Docker version at the time. I have tested LMS v8.3.1 which is the current version and it works fine, so Docker should no longer be necessary.

Now, on the issue of submitting the plugin... @balbuze , what's the correct approach in your opinion as I am just a contributor and not a co-author / owner in the strictest sense?
