### PR TITLE
feat(spotify): show all favorite tracks and albums

### DIFF
--- a/spotify/index.js
+++ b/spotify/index.js
@@ -13,6 +13,7 @@ var exec = require('child_process').exec;
 var execSync = require('child_process').execSync;
 var NodeCache = require('node-cache');
 var os = require('os');
+const { fetchPagedData, rateLimitedCall } = require('./utils/extendedSpotifyApi');
 
 var configFileDestinationPath = '/tmp/go-librespot-config.yml';
 var credentialsPath = '/data/configuration/music_service/spop/spotifycredentials.json';
@@ -1395,100 +1396,110 @@ ControllerSpotify.prototype.getMyPlaylists = function (curUri) {
     return defer.promise;
 };
 
-ControllerSpotify.prototype.getMyAlbums = function (curUri) {
-    var self = this;
-    var defer = libQ.defer();
+ControllerSpotify.prototype.getMyAlbums = function () {
+    const defer = libQ.defer();
+    const albums = [];
 
-    self.spotifyCheckAccessToken()
-        .then(function (data) {
-                var spotifyDefer = self.spotifyApi.getMySavedAlbums({limit: 50});
-                spotifyDefer.then(function (results) {
-                    var response = {
-                        navigation: {
-                            prev: {
-                                uri: 'spotify'
-                            },
-                            "lists": [
-                                {
-                                    "availableListViews": [
-                                        "list",
-                                        "grid"
-                                    ],
-                                    "items": []
-                                }
-                            ]
-                        }
-                    };
-
-                    for (var i in results.body.items) {
-                        var album = results.body.items[i].album;
-                        response.navigation.lists[0].items.push({
+    this.spotifyCheckAccessToken().then(() => {
+        fetchPagedData(
+            this.spotifyApi,
+            'getMySavedAlbums',
+            {},
+            {
+                onData: (items) => {
+                    for (var i in items) {
+                        var album = items[i].album;
+                        albums.push({
                             service: 'spop',
                             type: 'folder',
                             title: album.name,
-                            albumart: self._getAlbumArt(album),
+                            albumart: this._getAlbumArt(album),
                             uri: album.uri
                         });
                     }
-                    defer.resolve(response);
-                }, function (err) {
-                    self.logger.error('An error occurred while listing Spotify my albums ' + err);
-                    self.handleBrowsingError(err);
-                    defer.reject('');
-                });
+                },
+                onEnd: () => {
+                    albums.sort((a, b) => (a.year > b.year ? 1 : a.year === b.year ? 0 : -1));
+                    albums.sort((a, b) => (a.artist > b.artist ? 1 : a.artist === b.artist ? 0 : -1));
+                    defer.resolve({
+                        navigation: {
+                            prev: {
+                                uri: 'spotify',
+                            },
+                            lists: [
+                                {
+                                    availableListViews: ['list', 'grid'],
+                                    items: albums,
+                                },
+                            ],
+                        },
+                    });
+                },
             }
-        );
+        ).catch((err) => {
+            this.logger.error('An error occurred while listing Spotify my albums ' + err);
+            this.handleBrowsingError(err);
+            defer.reject('');
+        });
+    });
 
     return defer.promise;
 };
 
-ControllerSpotify.prototype.getMyTracks = function (curUri) {
-    var self = this;
-    var defer = libQ.defer();
+ControllerSpotify.prototype.getMyTracks = function () {
+    const defer = libQ.defer();
+    const tracks = [];
 
-    self.spotifyCheckAccessToken()
-        .then(function (data) {
-                var spotifyDefer = self.spotifyApi.getMySavedTracks({limit: 50});
-                spotifyDefer.then(function (results) {
-                    var response = {
-                        navigation: {
-                            prev: {
-                                uri: 'spotify'
-                            },
-                            "lists": [
-                                {
-                                    "availableListViews": [
-                                        "list"
-                                    ],
-                                    "items": []
-                                }
-                            ]
-                        }
-                    };
-
-                    for (var i in results.body.items) {
-                        var track = results.body.items[i].track;
-                        if (self.isTrackAvailableInCountry(track)) {
-                            response.navigation.lists[0].items.push({
+    this.spotifyCheckAccessToken().then(() => {
+        fetchPagedData(
+            this.spotifyApi,
+            'getMySavedTracks',
+            {},
+            {
+                onData: (items) => {
+                    for (var i in items) {
+                        var track = items[i].track;
+                        if (this.isTrackAvailableInCountry(track)) {
+                            tracks.push({
                                 service: 'spop',
                                 type: 'song',
                                 title: track.name,
-                                artist: track.artists[0].name || null,
+                                artist: track.artists[0] ? track.artists[0].name : null,
                                 album: track.album.name || null,
-                                albumart: self._getAlbumArt(track.album),
+                                albumart: this._getAlbumArt(track.album),
                                 uri: track.uri
                             });
                         }
                     }
-                    defer.resolve(response);
-                }, function (err) {
-                    self.logger.error('An error occurred while listing Spotify my tracks ' + err);
-                    self.handleBrowsingError(err);
-                    defer.reject('');
-                });
+                },
+                onEnd: () => {
+                    tracks.sort((a, b) =>
+                        a.tracknumber > b.tracknumber ? 1 : a.tracknumber === b.tracknumber ? 0 : -1
+                    );
+                    tracks.sort((a, b) => (a.year > b.year ? 1 : a.year === b.year ? 0 : -1));
+                    tracks.sort((a, b) => (a.album > b.album ? 1 : a.album === b.album ? 0 : -1));
+                    tracks.sort((a, b) => (a.artist > b.artist ? 1 : a.artist === b.artist ? 0 : -1));
+                    defer.resolve({
+                        navigation: {
+                            prev: {
+                                uri: 'spotify',
+                            },
+                            lists: [
+                                {
+                                    availableListViews: ['list'],
+                                    items: tracks,
+                                },
+                            ],
+                        },
+                    });
+                },
             }
-        );
-
+        ).catch((err) => {
+            this.logger.error('An error occurred while listing Spotify my tracks ' + err);
+            this.handleBrowsingError(err);
+            defer.reject('');
+        });
+    });
     return defer.promise;
 };
 
@@ -2237,20 +2248,19 @@ ControllerSpotify.prototype.getAlbumTracks = function (id) {
 
 
 ControllerSpotify.prototype.getPlaylistTracks = function (userId, playlistId) {
-    var self = this;
     var defer = libQ.defer();
+    var response = [];
 
-    self.spotifyCheckAccessToken()
-        .then(function (data) {
-            var spotifyDefer = self.spotifyApi.getPlaylist(playlistId);
-            spotifyDefer.then(function (results) {
-
-                var response = [];
-
-                for (var i in results.body.tracks.items) {
-                    var track = results.body.tracks.items[i].track;
-                    if (self.isTrackAvailableInCountry(track)) {
-                        try {
+    this.spotifyCheckAccessToken().then(() => {
+        fetchPagedData(
+            this.spotifyApi,
+            'getPlaylistTracks',
+            { requiredArgs: [playlistId] },
+            {
+                onData: (items) => {
+                    for (var i in items) {
+                        var track = items[i].track;
+                        if (this.isTrackAvailableInCountry(track)) {
                             var item = {
                                 service: 'spop',
                                 type: 'song',
@@ -2268,16 +2278,19 @@ ControllerSpotify.prototype.getPlaylistTracks = function (userId, playlistId) {
                                 duration: Math.trunc(track.duration_ms / 1000)
                             };
                             response.push(item);
-                        } catch(e) {}
+                        }
                     }
-                }
-                defer.resolve(response);
-            }, function (err) {
-                self.logger.error('An error occurred while exploding listing Spotify playlist tracks ' + err);
-                self.handleBrowsingError(err);
-                defer.reject(err);
-            });
+                },
+                onEnd: () => {
+                    defer.resolve(response);
+                },
+            }
+        ).catch((err) => {
+            this.logger.error('An error occurred while exploding listing Spotify playlist tracks ' + err);
+            this.handleBrowsingError(err);
+            defer.reject(err);
         });
+    });
 
     return defer.promise;
 };
@@ -2413,42 +2426,39 @@ ControllerSpotify.prototype.getPlaylistInfo = function (userId, playlistId) {
 }
 
 ControllerSpotify.prototype.getTrack = function (id) {
-    var self = this;
     var defer = libQ.defer();
 
-    self.spotifyCheckAccessToken()
-        .then(function (data) {
-            var spotifyDefer = self.spotifyApi.getTrack(id);
-            spotifyDefer.then(function (results) {
-
+    this.spotifyCheckAccessToken().then(() => {
+        rateLimitedCall(this.spotifyApi, 'getTrack', { args: [id], logger: this.logger })
+            .then((results) => {
+                const track = results.body;
                 var response = [];
                 var artist = '';
                 var album = '';
-                var title = '';
                 var albumart = '';
 
-                if (results.body.artists.length > 0) {
-                    artist = results.body.artists[0].name;
+                if (track.artists.length > 0) {
+                    artist = track.artists[0].name;
                 }
 
-                if (results.body.hasOwnProperty('album') && results.body.album.hasOwnProperty('name')) {
-                    album = results.body.album.name;
+                if (track.hasOwnProperty('album') && track.album.hasOwnProperty('name')) {
+                    album = track.album.name;
                 }
 
-                if (results.body.album.hasOwnProperty('images') && results.body.album.images.length > 0) {
-                    albumart = results.body.album.images[0].url;
+                if (track.album.hasOwnProperty('images') && track.album.images.length > 0) {
+                    albumart = track.album.images[0].url;
                 } else {
                     albumart = '';
                 }
 
                 var item = {
-                    uri: results.body.uri,
+                    uri: track.uri,
                     service: 'spop',
-                    name: results.body.name,
+                    name: track.name,
                     artist: artist,
                     album: album,
                     type: 'song',
-                    duration: parseInt(results.body.duration_ms / 1000),
+                    duration: parseInt(track.duration_ms / 1000),
                     albumart: albumart,
                     samplerate: self.getCurrentBitrate(),
                     bitdepth: '16 bit',
@@ -2457,11 +2467,13 @@ ControllerSpotify.prototype.getTrack = function (id) {
                     trackType: 'spotify'
                 };
                 response.push(item);
-                self.debugLog('GET TRACK: ' + JSON.stringify(response));
+                this.debugLog('GET TRACK: ' + JSON.stringify(response));
                 defer.resolve(response);
+            })
+            .catch((e) => {
+                defer.reject(e);
             });
-        });
-
+    });
     return defer.promise;
 };
 
@@ -2833,4 +2845,8 @@ ControllerSpotify.prototype.startVolumeTimerLimit = function () {
     volumeTimer = setInterval(() => {
         apiCallsCounter = 0;
     }, apiCallsTimespan);
+};
+
+ControllerSpotify.prototype.handleBrowsingError = function (errorMsg) {
+    this.commandRouter.pushToastMessage('error', 'Spotify API Error', errorMsg.toString());
 };

--- a/spotify/utils/extendedSpotifyApi/fetchPagedData.js
+++ b/spotify/utils/extendedSpotifyApi/fetchPagedData.js
@@ -1,0 +1,33 @@
+const limit = 50;
+
+async function fetchPagedData(
+  api,
+  method,
+  { requiredArgs = [], options, paginationType = 'offset' },
+  { getItems = (d) => d.body?.items || [], onData, onEnd }
+) {
+  let offset = 0;
+  let after = undefined;
+
+  const nextPage = {
+    offset: () => (offset += limit),
+    after: (items) => (after = items[items.length - 1].id),
+  };
+
+  while (true) {
+    const data = await api[method](...[...requiredArgs, { ...options, limit, offset, after }]);
+    const items = getItems(data);
+    if (!items.length) {
+      onEnd();
+      break;
+    }
+    onData(items);
+    if (items.length < limit) {
+      onEnd();
+      break;
+    }
+    nextPage[paginationType](items);
+  }
+}
+
+module.exports.fetchPagedData = fetchPagedData;

--- a/spotify/utils/extendedSpotifyApi/index.js
+++ b/spotify/utils/extendedSpotifyApi/index.js
@@ -1,0 +1,4 @@
+const { fetchPagedData } = require('./fetchPagedData');
+const { rateLimitedCall } = require('./rateLimitedCall');
+
+module.exports = { fetchPagedData, rateLimitedCall };

--- a/spotify/utils/extendedSpotifyApi/rateLimitedCall.js
+++ b/spotify/utils/extendedSpotifyApi/rateLimitedCall.js
@@ -1,0 +1,56 @@
+const COOLDOWN_PERIOD = 10000;
+const MAX_ATTEMPTS = 10;
+
+let isCooldown = false;
+let timeoutRef = null;
+
+function cooldown() {
+  clearTimeout(timeoutRef);
+  isCooldown = true;
+  timeoutRef = setTimeout(() => {
+    isCooldown = false;
+  }, COOLDOWN_PERIOD);
+}
+
+function waitForCooldown() {
+  return new Promise((resolve) => {
+    if (!isCooldown) {
+      resolve();
+      return;
+    }
+    const int = setInterval(() => {
+      if (!isCooldown) {
+        clearInterval(int);
+        resolve();
+      }
+    }, 1000);
+  });
+}
+
+function call(api, method, { logger, args, attempt } = {}) {
+  if (attempt > MAX_ATTEMPTS) {
+    return Promise.reject(new Error(`Giving up API request ${method} after ${MAX_ATTEMPTS} attempts`));
+  }
+
+  return new Promise(async (resolve, reject) => {
+    try {
+      await waitForCooldown();
+      const data = await api[method](...args);
+      resolve(data);
+    } catch (e) {
+      if (e.statusCode === 429) {
+        logger.warn(
+          `Spotify API method ${method} failed due to "Too many requests". Stop all API requests for ${COOLDOWN_PERIOD} milliseconds.`
+        );
+        cooldown();
+        call(api, method, { logger, args, attempt: attempt + 1 })
+          .then((x) => resolve(x))
+          .catch((x) => reject(x));
+        return;
+      }
+      reject(new Error(`Spotify API method ${method} failed: ${e}`));
+    }
+  });
+}
+
+module.exports.rateLimitedCall = call;


### PR DESCRIPTION
Done for:

- My tracks
- My albums
- Playlist -> tracks

Also fixed related issue with failing API requests with "Too many requests" error, because now it gets track info for all tracks in library. Introduced a way to stop sending API requests and wait for some time to be saved from Spotify web [API's rate limits](https://developer.spotify.com/documentation/web-api/concepts/rate-limits).