### PR TITLE
feat(spotify): add Followed Artists page 

### DIFF
--- a/spotify/UIConfig.json
+++ b/spotify/UIConfig.json
@@ -39,7 +39,8 @@
           "playlist-read-private",
           "playlist-read-collaborative",
           "app-remote-control",
-          "streaming"
+          "streaming",
+          "user-follow-read"
         ]}
       },
       {

--- a/spotify/i18n/strings_en.json
+++ b/spotify/i18n/strings_en.json
@@ -32,6 +32,7 @@
   "MY_PLAYLISTS":"My Playlists",
   "MY_ALBUMS":"My Albums",
   "MY_TRACKS":"My Tracks",
+  "MY_ARTISTS": "My Artists",
   "MY_TOP_ARTISTS":"My Top Artists",
   "MY_TOP_TRACKS":"My Top Tracks",
   "MY_RECENTLY_PLAYED_TRACKS":"My Recently Played Tracks",

--- a/spotify/index.js
+++ b/spotify/index.js
@@ -1174,6 +1174,8 @@ ControllerSpotify.prototype.handleBrowseUri = function (curUri) {
             response = self.getMyAlbums(curUri);
         } else if (curUri.startsWith('spotify/mytracks')) {
             response = self.getMyTracks(curUri);
+        } else if (curUri.startsWith('spotify/myartists')) {
+            response = self.getMyArtists(curUri);
         } else if (curUri.startsWith('spotify/mytopartists')) {
             response = self.getTopArtists(curUri);
         } else if (curUri.startsWith('spotify/mytoptracks')) {
@@ -1275,11 +1277,11 @@ ControllerSpotify.prototype.listRoot = function (curUri) {
                         {
                             service: 'spop',
                             type: 'streaming-category',
-                            title: self.getI18n('MY_TOP_ARTISTS'),
+                            title: self.getI18n('MY_ARTISTS'),
                             artist: '',
                             album: '',
                             albumart: '/albumart?sourceicon=music_service/spop/icons/artist.png',
-                            uri: 'spotify/mytopartists'
+                            uri: 'spotify/myartists',
                         },
                         {
                             service: 'spop',
@@ -1289,6 +1291,15 @@ ControllerSpotify.prototype.listRoot = function (curUri) {
                             album: '',
                             albumart: '/albumart?sourceicon=music_service/spop/icons/track.png',
                             uri: 'spotify/mytoptracks'
+                        },
+                        {
+                            service: 'spop',
+                            type: 'streaming-category',
+                            title: self.getI18n('MY_TOP_ARTISTS'),
+                            artist: '',
+                            album: '',
+                            icon: 'fa fa-diamond',
+                            uri: 'spotify/mytopartists'
                         },
                         {
                             service: 'spop',
@@ -1513,8 +1524,57 @@ ControllerSpotify.prototype.getMyTracks = function () {
     return defer.promise;
 };
 
-ControllerSpotify.prototype.getTopArtists = function (curUri) {
+ControllerSpotify.prototype.getMyArtists = function () {
+    const defer = libQ.defer();
+    const artists = [];
 
+    this.spotifyCheckAccessToken().then(() => {
+        fetchPagedData(
+            this.spotifyApi,
+            'getFollowedArtists',
+            { paginationType: 'after' },
+            {
+                getItems: (data) => data.body?.artists?.items || [],
+                onData: (items) => {
+                    for (var i in items) {
+                        const artist = items[i];
+                        artists.push({
+                            service: 'spop',
+                            type: 'folder',
+                            title: artist.name,
+                            albumart: this._getAlbumArt(artist),
+                            uri: artist.uri,
+                        });
+                    }
+                },
+                onEnd: () => {
+                    artists.sort((a, b) => (a.title > b.title ? 1 : a.title === b.title ? 0 : -1));
+                    defer.resolve({
+                        navigation: {
+                            prev: {
+                                uri: 'spotify',
+                            },
+                            lists: [
+                                {
+                                    availableListViews: ['list', 'grid'],
+                                    items: artists,
+                                },
+                            ],
+                        },
+                    });
+                },
+            }
+        ).catch((err) => {
+            this.logger.error('An error occurred while listing Spotify my artists ' + err);
+            this.handleBrowsingError(err);
+            defer.reject('');
+        });
+    });
+
+    return defer.promise;
+};
+
+ControllerSpotify.prototype.getTopArtists = function (curUri) {
     var self = this;
 
     var defer = libQ.defer();


### PR DESCRIPTION
Brings "My Artists" page into Spotify home page. API request for this one requires `user-follow-read` scope and later requires logout and login again to get new scopes on consumer device.
