### PR TITLE
keep camilladsp in background, fix mpd malloc() crash

### DIFF
--- a/fusion/asound/volumioDsp.postDsp.10.conf
+++ b/fusion/asound/volumioDsp.postDsp.10.conf
@@ -1,15 +1,17 @@
 #------ FusionDsp section -------
 pcm.volumioDsp {
   type plug
-  slave.pcm "fusiondsphook"
+  slave {
+    format "S32_LE"
+    channels 2
+    pcm "fusiondsphook"
+  }
 }
 
 pcm.fusiondsphook {
   type volumiohook
   slave.pcm "fusiondspfifo"
-  hw_params_command "echo %r >/tmp/sr.log && sleep 1.5 && /data/plugins/audio_interface/fusiondsp/camilladsp -p 9876 -l warn -o /tmp/camilladsp.log -r %r -f $(echo '%f' | sed 's/_//') -n 2 /data/configuration/audio_interface/fusiondsp/camilladsp.yml &"
-  hw_free_command "tail --pid `pidof camilladsp` -f /dev/null"
-  debug 1
+  hw_params_command "echo '%r,%f,%c,%d' >/tmp/fusiondsp_stream_params.log"
 }
 
 pcm.fusiondspfifo {

--- a/fusion/camilladsp-js.js
+++ b/fusion/camilladsp-js.js
@@ -20,16 +20,6 @@ let CamillaDsp = function (logger) {
     let self = this;
 
     /**
-     * Listener for SIGTERM signal, installed on class creation
-     * to terminate camilladsp process in case of killall/kill -SIGTERM
-     */
-    let listenerTerm = function() {
-
-        self.stop();
-
-    };
-
-    /**
      * Listener sent on camilladsp process termination.
      * The process may terminate either because FIFO has been closed (hence
      * we need to respawn the process immediately) or because of an error.
@@ -41,9 +31,12 @@ let CamillaDsp = function (logger) {
 
         logger.debug("close event");
 
+        // .stop() has been called, hence the process is supposed to
+        // not to be respawned. Just stop here in case.
         if (run === false)
             return;
 
+        // camilldsp exit with error, wait a second before respawn
         if (code > 0)
             timeout = 1000;
 
@@ -111,10 +104,10 @@ let CamillaDsp = function (logger) {
      */
     this.stop = function() {
 
+        run = false;
+
         if (camilla === null)
             return;
-
-        run = false;
 
         camilla.kill();
         camilla = null;
@@ -122,10 +115,6 @@ let CamillaDsp = function (logger) {
         logger.info("camilladsp service terminated");
 
     }
-
-    // Install the signal handler on SIGTERM to kill the child process
-    // and avoid dangling processes
-    process.on("SIGTERM", listenerTerm);
 
 };
 

--- a/fusion/camilladsp-js.js
+++ b/fusion/camilladsp-js.js
@@ -22,7 +22,7 @@ let CamillaDsp = function (logger) {
     let uniqueid = ++counter;
 
     /**
-     * Listener sent on camilladsp process termination.
+     * Listener for event sent on camilladsp process termination.
      * The process may terminate either because FIFO has been closed (hence
      * we need to respawn the process immediately) or because of an error.
      * In case of error, we wait for a second to avoid hogging CPU
@@ -70,7 +70,7 @@ let CamillaDsp = function (logger) {
     };
 
     /**
-     * Internal function to spawn the camilladsp process.
+     * Private function to spawn the camilladsp process.
      * If the process is already started (ie: camilla !== null), does not
      * spawn another process
      */
@@ -111,7 +111,7 @@ let CamillaDsp = function (logger) {
     };
 
     /**
-     * Internal function to stop camilladsp process. If there is no process running
+     * Private function to stop camilladsp process. If there is no process running
      * (ie: camilla === null), does not do anything
      */
     let processStop = function() {

--- a/fusion/camilladsp-js.js
+++ b/fusion/camilladsp-js.js
@@ -13,7 +13,7 @@ let CamillaDsp = function (logger) {
 
     const cdPath = "/data/plugins/audio_interface/fusiondsp/camilladsp"
     const cdLog = "/tmp/camilladsp.log";
-    const cdLogLevel = "debug";
+    const cdLogLevel = "warn";
     const cdPortWs = 9876;
     const cdPathConfig = "/data/configuration/audio_interface/fusiondsp/camilladsp.yml";
 

--- a/fusion/camilladsp-js.js
+++ b/fusion/camilladsp-js.js
@@ -1,0 +1,133 @@
+"use strict";
+
+const { spawn } = require("child_process");
+
+/**
+ * CamillaDsp class to handle the external process
+ * spawned as child process
+ */
+let CamillaDsp = function (logger) {
+
+    const cdPath = "/data/plugins/audio_interface/fusiondsp/camilladsp"
+    const cdLog = "/tmp/camilladsp.log";
+    const cdLogLevel = "debug";
+    const cdPortWs = 9876;
+    const cdPathConfig = "/data/configuration/audio_interface/fusiondsp/camilladsp.yml";
+
+    let run = false;
+    let camilla = null;
+    let abortController = null;
+    let self = this;
+
+    /**
+     * Listener for SIGTERM signal, installed on class creation
+     * to terminate camilladsp process in case of killall/kill -SIGTERM
+     */
+    let listenerTerm = function() {
+
+        this.stop();
+
+    };
+
+    /**
+     * Listener sent on camilladsp process termination.
+     * The process may terminate either because FIFO has been closed (hence
+     * we need to respawn the process immediately) or because of an error.
+     * In case of error, we wait for a second to avoid hogging CPU
+     */
+    let listenerClose = function(code, signal) {
+
+        let timeout = 0;
+
+        logger.debug("close event");
+
+        if (run === false)
+            return;
+
+        if (code > 0)
+            timeout = 1000;
+
+        logger.debug(`camilladsp close event, exit code ${code}, signal ${signal}`);
+        logger.debug(`respawn in ${timeout} ms`);
+
+        setTimeout(function() {
+
+            if (run === false)
+                return;
+
+            self.start();
+
+        }, timeout);
+
+    };
+
+    /**
+     * Listener for "exit" process: here process is terminated but
+     * stdio is not yet closed (and we may still not have an exit code)
+     */
+    let listenerExit = function(code, signal) {
+
+        camilla = null;
+
+        logger.debug(`camilladsp exit event, exit code ${code}, signal ${signal}`);
+
+    };
+
+    /**
+     * Public function to spawn the camilladsp process and keep it
+     * running in the background
+     */
+    this.start = function() {
+
+        let args;
+
+        if (camilla !== null)
+            return;
+
+        args = [
+            "-p",
+            cdPortWs,
+            "-o",
+            cdLog,
+            "-l",
+            cdLogLevel,
+            cdPathConfig
+        ];
+
+        camilla = spawn(cdPath, args);
+
+        camilla.on("exit", listenerExit);
+        camilla.on("close", listenerClose);
+
+        run = true;
+
+        logger.info("camilladsp service started and running in background");
+
+    };
+
+    /**
+     * Public function to terminate the camilladsp process and stop
+     * it from respawning
+     */
+    this.stop = function() {
+
+        if (camilla === null)
+            return;
+
+        run = false;
+
+        camilla.kill();
+        camilla = null;
+
+        logger.info("camilladsp service terminated");
+
+    }
+
+    // Install the signal handler on SIGTERM to kill the child process
+    // and avoid dangling processes
+    process.on("SIGTERM", listenerTerm);
+
+};
+
+module.exports = { CamillaDsp };
+

--- a/fusion/camilladsp-js.js
+++ b/fusion/camilladsp-js.js
@@ -25,7 +25,7 @@ let CamillaDsp = function (logger) {
      */
     let listenerTerm = function() {
 
-        this.stop();
+        self.stop();
 
     };
 

--- a/fusion/camilladsp-js.js
+++ b/fusion/camilladsp-js.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const { execSync } = require("child_process");
 const { spawn } = require("child_process");
 
 /**
@@ -74,6 +75,8 @@ let CamillaDsp = function (logger) {
 
         let args;
 
+        run = true;
+
         if (camilla !== null)
             return;
 
@@ -92,8 +95,6 @@ let CamillaDsp = function (logger) {
         camilla.on("exit", listenerExit);
         camilla.on("close", listenerClose);
 
-        run = true;
-
         logger.info("camilladsp service started and running in background");
 
     };
@@ -104,13 +105,22 @@ let CamillaDsp = function (logger) {
      */
     this.stop = function() {
 
+        let pid;
+
         run = false;
 
         if (camilla === null)
             return;
 
+        pid = camilla.pid;
+
         camilla.kill();
         camilla = null;
+
+        logger.info(`camilladsp stopping service pid ${pid}...`);
+
+        // Hacky way to make this function synchronous
+        execSync(`while true; do grep camilladsp /proc/${pid}/cmdline || break; sleep 0.1; done`);
 
         logger.info("camilladsp service terminated");
 

--- a/fusion/camilladsp.conf.yml
+++ b/fusion/camilladsp.conf.yml
@@ -1,6 +1,6 @@
 
 devices:
-  samplerate: ${capturesamplerate}
+  samplerate: ${outputsamplerate}
   chunksize: ${chunksize}
   silence_threshold: -60
   silence_timeout: 3.0

--- a/fusion/index.js
+++ b/fusion/index.js
@@ -2454,6 +2454,11 @@ FusionDsp.prototype.checksamplerate = function () {
 
   self.pushstateSamplerate = null;
 
+  /**
+   * Callback invoked when fileStreamParams changes. In this callback
+   * we read the stream parameters, validate them and update camilladsp
+   * configuration file to accomodate changes
+   */
   let callbackRead = function(event, file) {
 
     let hcurrentsamplerate;
@@ -2470,14 +2475,15 @@ FusionDsp.prototype.checksamplerate = function () {
       self.logger.info(" ---- read samplerate, raw: " + content);
 
       [hcurrentsamplerate, hformat, hchannels, hbitdepth] = content.split(",");
-      if (self.pushstateSamplerate != hcurrentsamplerate)
-        needRestart = true;
 
       if (!hcurrentsamplerate)
         throw "invalid sample rate";
 
       if (isSamplerateUpdating === true)
         throw " ---- read samplerate skipped, rate is already updating; keeping " + self.pushstateSamplerate;
+
+      if (self.pushstateSamplerate != hcurrentsamplerate)
+        needRestart = true;
 
       isSamplerateUpdating = true;
 
@@ -2511,6 +2517,8 @@ FusionDsp.prototype.checksamplerate = function () {
 
   }
 
+  // Install a file watcher over fileStreamParams
+  // when the file changes, read the content and update the samplerate
   try {
 
     let watcher = fs.watch(fileStreamParams);

--- a/fusion/index.js
+++ b/fusion/index.js
@@ -106,6 +106,7 @@ FusionDsp.prototype.onStop = function () {
   self.socket.off()
   self.logger.info(logPrefix + ' Stopping FusionDsp service');
   self.camillaProcess.stop();
+  self.camillaProcess = null;
 
   exec("/usr/bin/sudo /bin/systemctl stop fusiondsp.service", {
     uid: 1000,

--- a/fusion/package.json
+++ b/fusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fusiondsp",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "description": "A complete Dsp centre for Volumio3",
   "main": "index.js",
   "repository": "https://github.com/balbuze/volumio-plugins/tree/alsa_modular/plugins/audio_interface/FusionDsp",


### PR DESCRIPTION
Some rework done to avoid reloading camilladsp on start/stop to keep it working in background as much as possible.
When the FIFO has no more data, the camilladsp process stalls and wait for new data. As soon as new data arrives, the process immediately restart processing it

This fixes the crashing issue with mpd and greatly reduces the gap between tracks, but also introduces a glitch when there is a sampling rate change: `pushState` message may not be sent soon enough by volumio state machine, hence the next track may start with a wrong sampling rate that gets fixed withing a second from the start.

CamillaDSP process handling is in a separate .js file which is imported at runtime to keep things separated from the main FusionDSP code.