### PR TITLE
 Bump version from go-librespot

### DIFF
--- a/spotify/install.sh
+++ b/spotify/install.sh
@@ -45,7 +45,7 @@ fi
 
 
 DAEMON_BASE_URL=https://github.com/devgianlu/go-librespot/releases/download/v
-VERSION=0.0.9
+VERSION=0.0.10
 DAEMON_ARCHIVE=go-librespot_linux_$ARCH.tar.gz
 DAEMON_DOWNLOAD_URL=$DAEMON_BASE_URL$VERSION/$DAEMON_ARCHIVE
 DAEMON_DOWNLOAD_PATH=/home/volumio/$DAEMON_ARCHIVE


### PR DESCRIPTION
Change go-librespot Version from 0.0.9 to 0.0.10
Fixes a wide range of issues.
Detailed information: https://github.com/devgianlu/go-librespot/releases/tag/v0.0.10