### PR TITLE
feat(spotify): add more device icons into settings

### DIFF
--- a/spotify/UIConfig.json
+++ b/spotify/UIConfig.json
@@ -159,17 +159,54 @@
             "value": "avr",
             "label": "AV Receiver"
           },
-          "options": [{
-            "value": "avr",
-            "label": "AV Receiver"
-          },
+          "options": [
+            {
+              "value": "avr",
+              "label": "AV Receiver"
+            },
             {
               "value": "speaker",
               "label": "Speaker"
             },
             {
               "value": "stb",
-              "label": "Set Top Box"
+              "label": "Set-Top Box"
+            },
+            {
+              "value": "computer",
+              "label": "Computer"
+            },
+            {
+              "value": "tablet",
+              "label": "Tablet"
+            },
+            {
+              "value": "smartphone",
+              "label": "Smartphone"
+            },
+            {
+              "value": "tv",
+              "label": "TV"
+            },
+            {
+              "value": "audio_dongle",
+              "label": "Audio dongle"
+            },
+            {
+              "value": "game_console",
+              "label": "Game console"
+            },
+            {
+              "value": "cast_video",
+              "label": "Chromecast"
+            },
+            {
+              "value": "cast_audio",
+              "label": "Cast for audio"
+            },
+            {
+              "value": "automobile",
+              "label": "Car device"
             }
           ]
         }


### PR DESCRIPTION
<img width="306" alt="Screenshot 2024-01-09 at 15 02 17" src="https://github.com/volumio/volumio-plugins-sources/assets/598919/50d5960b-e5c7-4504-af42-25426b755273">


Taken from https://github.com/spotify/web-api/issues/687

Do you want to sort it somehow?