### PR TITLE
Touch Display 3.3.8

### DIFF
--- a/touch_display/install.sh
+++ b/touch_display/install.sh
@@ -37,52 +37,39 @@ TMP_DIR="$(mktemp -dt "$PLUGIN_NAME"-XXXXXXXXXX)" || { echo "Creating temporary 
 
 export DEBIAN_FRONTEND=noninteractive
 
+echo "Re-synchronizing package index files from their sources"
+apt-get update || { echo "Running apt-get update failed"; exit 1; }
+apt-get -y install || { echo "Running apt-get -y install failed"; exit 1; }
+
+echo "Installing graphical environment"
+apt-get -y install xinit || { echo "Installation of xinit failed"; exit 1; }
+apt-get -y install xorg || { echo "Installation of xorg failed"; exit 1; }
+apt-get -y install openbox || { echo "Installation of openbox failed"; exit 1; }
+
+echo "Creating /etc/X11/xorg.conf.d dir"
+mkdir -p /etc/X11/xorg.conf.d || { echo "Creating /etc/X11/xorg.conf.d failed"; exit 1; }
+
+echo "Creating Xorg configuration"
+echo "# This file is managed by the Touch Display plugin: Do not alter!
+# It will be deleted when the Touch Display plugin gets uninstalled.
+Section \"InputClass\"
+    Identifier \"Touch rotation\"
+    MatchIsTouchscreen \"on\"
+    MatchDevicePath \"/dev/input/event*\"
+    MatchDriver \"libinput|evdev\"
+EndSection" > /etc/X11/xorg.conf.d/95-touch_display-plugin.conf || { echo "Creating Xorg configuration file 95-touch_display-plugin.conf failed"; exit 1; }
+
 if grep -q Raspberry /proc/cpuinfo; then # on Raspberry Pi hardware
-  echo "Installing fake packages for kernel, bootloader and pi lib"
-  wget https://repo.volumio.org/Volumio2/Binaries/arm/libraspberrypi0_0.0.1_all.deb -P "$TMP_DIR" || { echo "Download of libraspberrypi0_0.0.1_all.deb failed"; exit 1; }
-  wget https://repo.volumio.org/Volumio2/Binaries/arm/raspberrypi-bootloader_0.0.1_all.deb -P "$TMP_DIR" || { echo "Download of raspberrypi-bootloader_0.0.1_all.deb failed"; exit 1; }
-  wget https://repo.volumio.org/Volumio2/Binaries/arm/raspberrypi-kernel_0.0.1_all.deb -P "$TMP_DIR" || { echo "Download of raspberrypi-kernel_0.0.1_all.deb failed"; exit 1; }
-  dpkg -i "$TMP_DIR"/libraspberrypi0_0.0.1_all.deb || { echo "Installation of libraspberrypi0_0.0.1_all.deb failed"; exit 1; }
-  dpkg -i "$TMP_DIR"/raspberrypi-bootloader_0.0.1_all.deb || { echo "Installation of raspberrypi-bootloader_0.0.1_all.deb failed"; exit 1; }
-  dpkg -i "$TMP_DIR"/raspberrypi-kernel_0.0.1_all.deb || { echo "Installation of raspberrypi-kernel_0.0.1_all.deb failed"; exit 1; }
-
-  echo "Putting on hold packages for kernel, bootloader and pi lib"
-  apt-mark hold libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel || { echo "Putting on hold packages for kernel, bootloader and pi lib failed"; exit 1; }
-
-  echo "Re-synchronizing package index files from their sources"
-  apt-get update || { echo "Running apt-get update failed"; exit 1; }
-  apt-get -y install || { echo "Running apt-get -y install failed"; exit 1; }
-
-  echo "Installing graphical environment"
-  apt-get -y install xinit || { echo "Installation of xinit failed"; exit 1; }
-  apt-get -y install xorg || { echo "Installation of xorg failed"; exit 1; }
-  apt-get -y install openbox || { echo "Installation of openbox failed"; exit 1; }
+  echo "Section \"OutputClass\"
+    Identifier \"vc4\"
+    MatchDriver \"vc4\"
+    Driver \"modesetting\"
+    Option \"PrimaryGPU\" \"true\"
+EndSection" > /etc/X11/xorg.conf.d/99-vc4.conf || { echo "Creating Xorg configuration file 99-vc4.conf failed"; exit 1; }
 
   echo "Installing Chromium"
   apt-get -y install chromium-browser || { echo "Installation of Chromium failed"; exit 1; }
-
-  echo "Creating /etc/X11/xorg.conf.d dir"
-  mkdir -p /etc/X11/xorg.conf.d || { echo "Creating /etc/X11/xorg.conf.d failed"; exit 1; }
-
-  echo "Creating Xorg configuration file"
-  echo "# This file is managed by the Touch Display plugin: Do not alter!
-# It will be deleted when the Touch Display plugin gets uninstalled.
-Section \"InputClass\"
-        Identifier \"Touch rotation\"
-        MatchIsTouchscreen \"on\"
-        MatchDevicePath \"/dev/input/event*\"
-        MatchDriver \"libinput|evdev\"
-EndSection" > /etc/X11/xorg.conf.d/95-touch_display-plugin.conf || { echo "Creating Xorg configuration file failed"; exit 1; }
 else # on other hardware
-  echo "Re-synchronizing package index files from their sources"
-  apt-get update || { echo "Running apt-get update failed"; exit 1; }
-  apt-get -y install || { echo "Running apt-get -y install failed"; exit 1; }
-
-  echo "Installing graphical environment"
-  apt-get -y install xinit || { echo "Installation of xinit failed"; exit 1; }
-  apt-get -y install xorg || { echo "Installation of xorg failed"; exit 1; }
-  apt-get -y install openbox || { echo "Installation of openbox failed"; exit 1; }
-
   echo "Installing Chromium"
   apt-get -y install chromium || { echo "Installation of Chromium failed"; exit 1; }
   ln -fs /usr/bin/chromium /usr/bin/chromium-browser || { echo "Linking /usr/bin/chromium to /usr/bin/chromium-browser failed"; exit 1; }
@@ -138,5 +125,8 @@ WantedBy=multi-user.target
 " > /lib/systemd/system/volumio-kiosk.service || { echo "Creating Systemd Unit for Kiosk failed"; exit 1; }
 systemctl daemon-reload
 
+echo "Disabling login prompt"
+systemctl disable getty@tty1.service
+
 echo "Allowing volumio to start an xsession"
-sed -i "s/allowed_users=console/allowed_users=anybody/" /etc/X11/Xwrapper.config || { echo "Allowing volumio to start an xsession failed"; exit 1; }
+sed -i "s/allowed_users=console/allowed_users=anybody\nneeds_root_rights=yes/" /etc/X11/Xwrapper.config || { echo "Allowing volumio to start an xsession failed"; exit 1; }

--- a/touch_display/package.json
+++ b/touch_display/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "touch_display",
-	"version": "3.3.7",
+	"version": "3.3.8",
 	"description": "The plugin enables displaying and operating Volumio's UI on a locally connected screen. NOTE: The plugin cannot be installed on systems that have a factory option to display the UI via HDMI video output.",
 	"main": "index.js",
 	"scripts": {
@@ -20,7 +20,7 @@
 			"buster"
 		],
 		"details": "The plugin enables the display of Volumio's UI on locally connected screens. If the screen offers touch control, apart from keyboard input the UI can be operated from the screen.<br><br>The plugin focuses on the Raspberry Pi Foundation's 7\" display (and compatible DSI displays), but can in principle also be used with displays connected via HDMI or GPIO. However, HDMI and GPIO displays usually require additional action by the user, depending on the type of display and any touch controller present, and <b>requiring advanced knowledge</b>.<br><br><b style=\"color:red;\">NOTE: The plugin cannot be installed on systems that have a factory option to display the UI via HDMI video output.</b>",
-		"changelog": "Fixed: Prevent installation on Tinkerboard"
+		"changelog": "Fixed: System damage on uninstalling; adaptions for Pi overlay vc4-kms-v3d"
 	},
 	"engines": {
 		"node": ">=8",

--- a/touch_display/uninstall.sh
+++ b/touch_display/uninstall.sh
@@ -5,19 +5,13 @@ apt-get -y purge --auto-remove fonts-arphic-ukai
 apt-get -y purge --auto-remove fonts-arphic-gbsn00lp
 apt-get -y purge --auto-remove fonts-unfonts-core
 if grep -q Raspberry /proc/cpuinfo; then # on Raspberry Pi hardware
-  apt-mark unhold libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel
   apt-get -y purge --auto-remove chromium-browser
-  apt-get -y purge --auto-remove openbox
-  apt-get -y purge --auto-remove xinit
-  apt-get -y purge --auto-remove libraspberrypi0
-  apt-get -y purge --auto-remove raspberrypi-bootloader
-  apt-get -y purge --auto-remove raspberrypi-kernel
 else # on other hardware
   apt-get -y purge --auto-remove chromium
-  apt-get -y purge --auto-remove openbox
-  apt-get -y purge --auto-remove xinit
   rm /usr/bin/chromium-browser
 fi
+apt-get -y purge --auto-remove openbox
+apt-get -y purge --auto-remove xinit
 
 echo "Deleting /opt/volumiokiosk.sh"
 rm /opt/volumiokiosk.sh
@@ -32,6 +26,14 @@ if [ -f /etc/X11/xorg.conf.d/95-touch_display-plugin.conf ]; then
   echo "Deleting /etc/X11/xorg.conf.d/95-touch_display-plugin.conf"
   rm /etc/X11/xorg.conf.d/95-touch_display-plugin.conf
 fi
+
+if [ -f /etc/X11/xorg.conf.d/99-vc4.conf ]; then
+  echo "Deleting /etc/X11/xorg.conf.d/99-vc4.conf"
+  rm /etc/X11/xorg.conf.d/99-vc4.conf
+fi
+
+echo "Enabling login prompt"
+systemctl enable getty@tty1.service
 
 echo "Done"
 echo "pluginuninstallend"


### PR DESCRIPTION
The plugin creates now "/etc/X11/xorg.conf.d/99-vc4.conf" for Pi systems to make Xorg work when "vc4-kms-3d" overlays are used. 

"needs_root_rights=yes" now gets added to /etc/X11/Xwrapper.config because automatic detection that root is needed seemingly does not work for some display drivers.

Also getty@tty1.service is now disabled on plugin install in order to remove the login prompt which was visible before browser starts.

Purging and unholding fake packages for kernel, bootloader and pi lib have been removed from the uninstall script to avoid damage to the Volumio system.