### PR TITLE
Bump go-librespot version

### DIFF
--- a/spotify/install.sh
+++ b/spotify/install.sh
@@ -45,7 +45,7 @@ fi
 
 
 DAEMON_BASE_URL=https://github.com/devgianlu/go-librespot/releases/download/v
-VERSION=0.0.10
+VERSION=0.0.14
 DAEMON_ARCHIVE=go-librespot_linux_$ARCH.tar.gz
 DAEMON_DOWNLOAD_URL=$DAEMON_BASE_URL$VERSION/$DAEMON_ARCHIVE
 DAEMON_DOWNLOAD_PATH=/home/volumio/$DAEMON_ARCHIVE


### PR DESCRIPTION
Bump version from v0.0.10 to v0.0.14
Fixes https://github.com/volumio/volumio-plugins-sources/issues/318 and some other issues.
Changelog: https://github.com/devgianlu/go-librespot/compare/v0.0.10...v0.0.14