### PR TITLE
feat(spotify): Use the new endpoints for oauth

### DIFF
--- a/spotify/UIConfig.json
+++ b/spotify/UIConfig.json
@@ -27,7 +27,7 @@
         "element": "button",
         "label": "TRANSLATE.AUTHORIZE",
         "description": "TRANSLATE.AUTHORIZE_PERSONAL_CONTENT",
-        "onClick": {"type":"oauth", "performerUrl":"http://oauth-performer.dfs.volumio.org/spotify","plugin":"music_service/spop", "scopes":[
+        "onClick": {"type":"oauth", "performerUrl":"https://oauth-performer.prod.vlmapi.io/spotify","plugin":"music_service/spop", "scopes":[
           "user-modify-playback-state",
           "user-read-playback-state",
           "user-read-currently-playing",

--- a/spotify/index.js
+++ b/spotify/index.js
@@ -829,7 +829,7 @@ ControllerSpotify.prototype.refreshAccessToken = function () {
 
     var refreshToken = self.config.get('refresh_token', 'none');
     if (refreshToken !== 'none' && refreshToken !== null && refreshToken !== undefined) {
-        superagent.post('https://oauth-performer.dfs.volumio.org/spotify/accessToken')
+        superagent.post('https://oauth-performer.prod.vlmapi.io/spotify/accessToken')
             .send({refreshToken: refreshToken})
             .then(function (results) {
                 if (results && results.body && results.body.accessToken) {


### PR DESCRIPTION
As we're moving to a new backend infrastructure, we need to switch the endpoint used by the Spotify plugin to perform the OAuth authentication.