### PR TITLE
Update spop plugin with new go-librespot

### DIFF
--- a/spotify/UIConfig.json
+++ b/spotify/UIConfig.json
@@ -84,6 +84,8 @@
           "debug",
           "normalisation_pregain",
           "enable_autoplay",
+          "audio_buffer_time",
+          "audio_period_count",
           "icon"
         ]
       },
@@ -198,6 +200,20 @@
           "doc": "Whether autoplay should be enabled after the current playback session ends",
           "label": "Enable autoplay",
           "value": true
+        },
+        {
+          "id": "audio_buffer_time",
+          "element": "input",
+          "doc": "The audio buffer time in microseconds.",
+          "label": "Audio buffer time",
+          "value": 500000
+        },
+        {
+          "id": "audio_period_count",
+          "element": "input",
+          "doc": "The number of audio periods to request.",
+          "label": "Audio period count",
+          "value": 4
         }
       ]
     }

--- a/spotify/config.yml.tmpl
+++ b/spotify/config.yml.tmpl
@@ -8,5 +8,7 @@ device_type: "${device_type}"
 bitrate: ${bitrate_number}
 external_volume: ${external_volume}
 normalisation_pregain: ${normalisation_pregain}
+audio_buffer_time: ${audio_buffer_time}
+audio_period_count: ${audio_period_count}
 zeroconf_enabled: true
 disable_autoplay: ${disable_autoplay}

--- a/spotify/index.js
+++ b/spotify/index.js
@@ -130,6 +130,12 @@ ControllerSpotify.prototype.getUIConfig = function () {
             var enableAutoplayValue = self.config.get('enable_autoplay', false);
             uiconf.sections[2].content[4].value = enableAutoplayValue;
 
+            var audioBufferTime = self.config.get('audio_buffer_time', 500_000);
+            uiconf.sections[2].content[5].value = audioBufferTime;
+
+            var audioPeriodCount = self.config.get('audio_period_count', 4);
+            uiconf.sections[2].content[6].value = audioPeriodCount;
+
             defer.resolve(uiconf);
         })
         .fail(function (error) {
@@ -743,13 +749,17 @@ ControllerSpotify.prototype.createConfigFile = function () {
     }
     var normalisationPregain = self.config.get('normalisation_pregain', '1.0');
     var enableAutoplay = self.config.get('enable_autoplay', false);
+    var audioBufferTime = self.config.get('audio_buffer_time', 500_000);
+    var audioPeriodCount = self.config.get('audio_period_count', 4);
 
     var conf = template.replace('${device_name}', devicename)
         .replace('${bitrate_number}', selectedBitrate)
         .replace('${device_type}', icon)
         .replace('${external_volume}', externalVolume)
         .replace('${normalisation_pregain}', normalisationPregain)
-        .replace('${disable_autoplay}', !enableAutoplay);
+        .replace('${disable_autoplay}', !enableAutoplay)
+        .replace('${audio_buffer_time}', audioBufferTime)
+        .replace('${audio_period_count}', audioPeriodCount);
 
     var credentials_type = self.config.get('credentials_type', 'zeroconf');
     var logged_user_id = self.config.get('logged_user_id', '');
@@ -818,6 +828,16 @@ ControllerSpotify.prototype.saveGoLibrespotSettings = function (data, avoidBroad
     }
     if (data.normalisation_pregain && data.normalisation_pregain.value !== undefined) {
         self.config.set('normalisation_pregain', data.normalisation_pregain.value);
+    }
+
+    var audioBufferTime = parseInt(data.audio_buffer_time);
+    if (audioBufferTime) {
+        self.config.set('audio_buffer_time', audioBufferTime.toString());
+    }
+
+    var audioPeriodCount = parseInt(data.audio_period_count);
+    if (audioPeriodCount) {
+        self.config.set('audio_period_count', audioPeriodCount.toString());
     }
 
     self.config.set('enable_autoplay', data.enable_autoplay);

--- a/spotify/install.sh
+++ b/spotify/install.sh
@@ -45,7 +45,7 @@ fi
 
 ## go-librespot
 DAEMON_BASE_URL=https://github.com/devgianlu/go-librespot/releases/download/v
-VERSION=0.2.0
+VERSION=0.3.2
 DAEMON_ARCHIVE=go-librespot_linux_$ARCH.tar.gz
 DAEMON_DOWNLOAD_URL=$DAEMON_BASE_URL$VERSION/$DAEMON_ARCHIVE
 DAEMON_DOWNLOAD_PATH=/home/volumio/$DAEMON_ARCHIVE

--- a/spotify/package.json
+++ b/spotify/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "spop",
-	"version": "4.1.4",
+	"version": "4.1.5",
 	"description": "Spotify plugin for Volumio3",
 	"main": "index.js",
 	"scripts": {

--- a/spotify/package.json
+++ b/spotify/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "spop",
-	"version": "4.1.5",
+	"version": "4.2.0",
 	"description": "Spotify plugin for Volumio3",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
This PR adds configurable audio buffers and updates go-librespot to 0.3.2.

See https://github.com/devgianlu/go-librespot/issues/189

Ultimately, this fixes https://community.volumio.com/t/spotify-issues-were-working-on-a-fix/73303